### PR TITLE
fix(security): address three medium-severity issues (#30, #31, #32)

### DIFF
--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -319,8 +319,10 @@ pub fn derive_session_key(
     // Salt is now supported (and recommended to be transcript hash)
     let hkdf = Hkdf::<Sha256>::new(salt, shared_secret.as_bytes());
 
-    // Initialize with random bytes to avoid any fixed-value key material pattern.
-    let mut session_key: [u8; AES_KEY_SIZE] = rand::random();
+    // HKDF.expand fully overwrites the buffer; zero-initialize so a future
+    // refactor that swaps .expect() for ? can't silently use uninitialized
+    // or random material as a session key.
+    let mut session_key = [0u8; AES_KEY_SIZE];
     hkdf.expand(info, &mut session_key)
         .expect("HKDF expand should not fail with valid length");
 
@@ -344,8 +346,10 @@ pub fn rekey_session_key(current_key: &[u8; AES_KEY_SIZE], nonce: &[u8; 16]) -> 
     // Nonce acts as salt for additional entropy
     let hkdf = Hkdf::<Sha256>::new(Some(nonce), current_key);
 
-    // Initialize with random bytes to avoid any fixed-value key material pattern.
-    let mut next_key: [u8; AES_KEY_SIZE] = rand::random();
+    // HKDF.expand fully overwrites the buffer; zero-initialize so a future
+    // refactor that swaps .expect() for ? can't silently use uninitialized
+    // or random material as a session key.
+    let mut next_key = [0u8; AES_KEY_SIZE];
     hkdf.expand(b"key-rotation", &mut next_key)
         .expect("HKDF expand should not fail with valid length");
 
@@ -427,6 +431,16 @@ impl AesCipher {
         let counter = self
             .nonce_counter
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        // Guard against counter wrap-around. `fetch_add` wraps on overflow, so
+        // letting `counter == u64::MAX` go through would mean the next call
+        // reuses nonce 0 — catastrophic for AES-GCM. The periodic rekey
+        // (REKEY_MESSAGE_COUNT = 100) makes this practically unreachable, but
+        // we fail loudly here as a defense-in-depth measure.
+        assert!(
+            counter < u64::MAX,
+            "AES-GCM nonce counter exhausted; session must be rekeyed before reuse"
+        );
 
         // Build nonce: session_id (4 bytes) || counter (8 bytes)
         let mut nonce_bytes = [0u8; crate::AES_NONCE_SIZE];

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -287,8 +287,17 @@ impl ProtocolMessage {
         }
 
         if b.starts_with(b"EPHEMERAL_KEY:") {
-            let public_key = b[14..].to_vec();
-            return Some(Self::EphemeralKey { public_key });
+            // Validate length before allocating: X25519 public keys are exactly
+            // 32 bytes. Reject anything else without copying the payload so a
+            // malicious peer can't force a multi-MiB allocation during the
+            // unauthenticated handshake phase.
+            let key_bytes = &b[14..];
+            if key_bytes.len() != 32 {
+                return None;
+            }
+            return Some(Self::EphemeralKey {
+                public_key: key_bytes.to_vec(),
+            });
         }
 
         if b.starts_with(b"TEXT:") {

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -89,6 +89,36 @@ fn test_binary_protocol_limits() {
 }
 
 #[test]
+fn test_legacy_ephemeral_key_rejects_oversized_payload() {
+    // Regression: a malicious peer could send an EPHEMERAL_KEY: payload larger
+    // than 32 bytes, causing the legacy parser to allocate the full body before
+    // any length check. Ensure such payloads are now rejected without copying.
+    let mut oversized = b"EPHEMERAL_KEY:".to_vec();
+    oversized.extend_from_slice(&vec![0u8; 8 * 1024 * 1024]);
+    assert!(
+        ProtocolMessage::from_plain_bytes(&oversized).is_none(),
+        "Oversized EPHEMERAL_KEY payload must be rejected"
+    );
+
+    let mut short = b"EPHEMERAL_KEY:".to_vec();
+    short.extend_from_slice(&[0u8; 16]);
+    assert!(
+        ProtocolMessage::from_plain_bytes(&short).is_none(),
+        "Undersized EPHEMERAL_KEY payload must be rejected"
+    );
+
+    let mut valid = b"EPHEMERAL_KEY:".to_vec();
+    valid.extend_from_slice(&[0u8; 32]);
+    assert!(
+        matches!(
+            ProtocolMessage::from_plain_bytes(&valid),
+            Some(ProtocolMessage::EphemeralKey { .. })
+        ),
+        "Exactly 32-byte EPHEMERAL_KEY payload must parse"
+    );
+}
+
+#[test]
 fn test_file_meta_parsing_robustness() {
     // Malformed metadata (size is not a number)
     let bad_meta = b"FILE_META|0|filename|not_a_number";


### PR DESCRIPTION
- #30: zero-initialize HKDF output buffers in derive_session_key and
  rekey_session_key instead of pre-filling with rand::random(). HKDF.expand
  fully overwrites the buffer, and the random pre-fill would silently become
  the session key if a future refactor swaps .expect() for `?`.

- #31: add an overflow guard to AesCipher::encrypt. fetch_add on an atomic
  u64 wraps on overflow, so reaching u64::MAX would cause nonce reuse on the
  next call. REKEY_MESSAGE_COUNT=100 makes this practically unreachable, but
  we now panic if the counter is about to wrap as a defense-in-depth.

- #32: validate EPHEMERAL_KEY: payload length before allocating in the
  legacy ASCII parser. Previously a malicious peer could force an 8 MiB
  allocation per connection attempt during the unauthenticated handshake
  phase. Now we reject anything other than exactly 32 bytes without copying.

Adds a regression test for #32 covering oversized, undersized, and valid
payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced cryptographic operations with runtime validation to prevent nonce counter overflow and protect against potential nonce reuse scenarios.
* Improved protocol message parsing by adding strict payload size validation for legacy ephemeral key messages, ensuring malformed inputs are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->