### PR TITLE
release: v1.10.1 — SQLite Party server persistence + CI workspace fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwayland-dev libxkbcommon-dev \
+            libwebkit2gtk-4.1-dev libsoup-3.0-dev librsvg2-dev \
+            libayatana-appindicator3-dev
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -45,7 +52,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwayland-dev libxkbcommon-dev
+          sudo apt-get install -y libgtk-3-dev libwayland-dev libxkbcommon-dev \
+            libwebkit2gtk-4.1-dev libsoup-3.0-dev librsvg2-dev \
+            libayatana-appindicator3-dev
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -68,7 +77,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwayland-dev libxkbcommon-dev
+          sudo apt-get install -y libgtk-3-dev libwayland-dev libxkbcommon-dev \
+            libwebkit2gtk-4.1-dev libsoup-3.0-dev librsvg2-dev \
+            libayatana-appindicator3-dev
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-06-28
+
 ### Changed
 
 - **Party server durability moved to embedded SQLite.** The server now mirrors its
@@ -485,6 +487,7 @@ This release transformed the application from a functional prototype into a poli
 - Message history persistence.
 
 [Unreleased]: #
+[1.10.1]: #
 [1.10.0]: #
 [1.9.0]: #
 [1.7.3]: #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Party server durability moved to embedded SQLite.** The server now mirrors its
+  state (members, channels, message + DM history) to a `party.db` SQLite database
+  under the operator's data dir, writing each change incrementally instead of
+  rewriting a whole JSON snapshot on every message. An existing `party_state.json`
+  snapshot is imported once on first start and then superseded. No configuration
+  change for operators; the runtime model and behavior are unchanged.
+
+### Fixed
+
+- CI now builds the whole workspace: installs the WebKitGTK system dependencies the
+  Tauri desktop crate needs, and applies `rustfmt` to that crate (both were missing
+  after it was merged into the workspace).
+
 ## [1.10.0] - 2026-06-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -321,7 +321,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1886,7 +1886,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2430,7 +2430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2483,6 +2483,18 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -3278,6 +3290,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -3294,6 +3315,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3486,7 +3516,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4032,6 +4062,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4320,7 @@ dependencies = [
  "anyhow",
  "messenger-core",
  "rsa",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -4516,7 +4558,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6358,6 +6400,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6418,7 +6474,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7513,7 +7569,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -7553,7 +7609,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8353,6 +8409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8984,7 +9046,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "encodeur_rsa_rust"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "messenger-core"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "messenger-server"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "messenger-core",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "p2pem-desktop"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ egui_commonmark = { version = "0.18", features = ["default"] }
 ratatui = { version = "0.30.0", features = ["crossterm_0_29", "underline-color", "all-widgets", "macros", "layout-cache"] }
 ratatui-crossterm = { version = "0.1.0", features = ["crossterm_0_29"] }
 
+# Embedded SQLite (bundled: compiles SQLite from source, no system dependency)
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # Utilities
 anyhow = "1"
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["core", "client", "server", "desktop/src-tauri"]
 default-members = ["client"]
 
 [workspace.package]
-version = "1.10.0"
+version = "1.10.1"
 edition = "2021"
 rust-version = "1.86"
 authors = ["fibo3090 <fibo3090@example.com>"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Encrypted P2P Messenger
 
-[![Version](https://img.shields.io/badge/version-1.10.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.10.1-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-orange)](LICENSE.md)
 [![Security](https://img.shields.io/badge/security-medium-yellow)](SECURITY.md)
 [![Rust](https://img.shields.io/badge/rust-1.86+-orange)](https://www.rust-lang.org/)

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -104,7 +104,8 @@ fn auth_status(state: tauri::State<'_, Bridge>) -> AuthStatus {
 async fn unlock(password: String, state: tauri::State<'_, Bridge>) -> Result<(), String> {
     let key = {
         let mut id = state.identity.lock().unwrap();
-        id.decrypt(&password).map_err(|_| "Wrong password".to_string())?;
+        id.decrypt(&password)
+            .map_err(|_| "Wrong password".to_string())?;
         let key = id.history_key().map_err(|e| e.to_string())?;
         *state.is_new.lock().unwrap() = false;
         *state.force_setup.lock().unwrap() = false;
@@ -143,9 +144,7 @@ fn my_identity(state: tauri::State<'_, Bridge>) -> AuthStatus {
 }
 
 #[tauri::command]
-async fn list_conversations(
-    state: tauri::State<'_, Bridge>,
-) -> Result<Vec<ConvSummary>, String> {
+async fn list_conversations(state: tauri::State<'_, Bridge>) -> Result<Vec<ConvSummary>, String> {
     let mgr = state.manager.lock().await;
     let mut out = Vec::new();
     for id in mgr.chat_ids() {
@@ -380,12 +379,16 @@ async fn my_invite_link(state: tauri::State<'_, Bridge>) -> Result<String, Strin
             .map(|ip| messenger_core::util::format_host_port(&ip, port))
     };
     let id = state.identity.lock().unwrap();
-    id.generate_signed_invite_link(address).map_err(|e| e.to_string())
+    id.generate_signed_invite_link(address)
+        .map_err(|e| e.to_string())
 }
 
 /// Parse an invite link and store it as a contact.
 #[tauri::command]
-async fn import_invite(link: String, state: tauri::State<'_, Bridge>) -> Result<ContactDto, String> {
+async fn import_invite(
+    link: String,
+    state: tauri::State<'_, Bridge>,
+) -> Result<ContactDto, String> {
     let contact = {
         let mgr = state.manager.lock().await;
         mgr.parse_invite_link(&link).map_err(|e| e.to_string())?
@@ -404,8 +407,9 @@ async fn connect_contact(id: String, state: tauri::State<'_, Bridge>) -> Result<
         mgr.get_contact(uuid).and_then(|c| c.address.clone())
     };
     let address = address.ok_or_else(|| "Contact has no saved address".to_string())?;
-    let (host, port) = messenger_core::util::parse_host_port(&address, Some(messenger_core::PORT_DEFAULT))
-        .map_err(|e| e.to_string())?;
+    let (host, port) =
+        messenger_core::util::parse_host_port(&address, Some(messenger_core::PORT_DEFAULT))
+            .map_err(|e| e.to_string())?;
     let pk = {
         let id = state.identity.lock().unwrap();
         id.private_key().map_err(|e| e.to_string())?
@@ -476,7 +480,11 @@ pub fn run() {
         ])
         .setup(|app| {
             let b = app.state::<Bridge>();
-            spawn_poll_loop(app.handle().clone(), b.manager.clone(), b.pending_fp.clone());
+            spawn_poll_loop(
+                app.handle().clone(),
+                b.manager.clone(),
+                b.pending_fp.clone(),
+            );
             Ok(())
         })
         .run(tauri::generate_context!())
@@ -554,7 +562,10 @@ fn spawn_poll_loop(
                 (req, toasts)
             };
             for (level, message) in toasts {
-                let _ = app.emit("toast", serde_json::json!({ "level": level, "message": message }));
+                let _ = app.emit(
+                    "toast",
+                    serde_json::json!({ "level": level, "message": message }),
+                );
             }
             if let Some((fingerprint, peer_name, chat_id)) = req {
                 let id = chat_id.to_string();

--- a/docs/03_architecture.md
+++ b/docs/03_architecture.md
@@ -170,7 +170,7 @@ server/src/
 ### `server/src/`
 
 - the Party server: TCP accept loop, `PartyState` (members/channels/DM
-  threads/history + JSON-snapshot persistence), request dispatcher, cross-connection
+  threads/history + embedded-SQLite persistence), request dispatcher, cross-connection
   broadcast hub, per-connection serve loop, and a persistent owner-only identity
 
 ### `client/src/app/party_manager.rs`

--- a/docs/05_platform_spec.md
+++ b/docs/05_platform_spec.md
@@ -74,7 +74,7 @@ In short: `core::party` defines the application protocol; `messenger-server` run
 real TCP listener with a persistent owner-only identity, applies requests to an
 in-memory `PartyState`, fans out live broadcasts across connections, serves
 channels and server-routed DMs with offline history catch-up, and persists state
-to a durable JSON snapshot. A client can join, chat in channels, DM, and create
+to an embedded SQLite database. A client can join, chat in channels, DM, and create
 channels via TUI commands and a GUI Party window.
 
 ### Current UI — egui + ratatui (to be replaced)
@@ -128,7 +128,7 @@ core/     crypto, protocol/wire types, framing, identity, transport, shared type
           and the Party application protocol (core::party). Reused by both sides.
 client/   the unified app: GUI + TUI, ChatManager, PartyManager, persistence.
 server/   the Party server: TCP listener, PartyState, dispatcher, broadcast hub,
-          persistent identity, durable snapshot.
+          persistent identity, SQLite store.
 ```
 
 Relay stays a thin mode (`--relay-server`) alongside `core`.
@@ -216,9 +216,11 @@ and server, riding on top of the v3 encrypted tunnel.
   member); a cross-connection **broadcast hub** (a posted message reaches every
   other connected member live); a **persistent owner-only server identity**
   (`server::identity`, RSA PEM under the data dir, so the pinned fingerprint is
-  stable across restarts); and **durable state** — `PartyState::load`/`persist`
-  auto-saves members + channels + DM threads + history to a JSON snapshot and
-  restores it on startup (presence resets to offline).
+  stable across restarts); and **durable state** — `PartyState::load` mirrors
+  members + channels + DM threads + history to an embedded **SQLite** database
+  (`party.db`), writing each mutation's delta and reconstructing the in-memory
+  model on startup (presence resets to offline); a legacy `party_state.json`
+  snapshot is imported once on first load.
 - **Server-routed DMs** — a deterministic per-pair DM thread; the server stores
   and delivers DMs like channels, with offline history.
 - **Channel creation** — members can create channels at runtime.
@@ -231,17 +233,22 @@ and server, riding on top of the v3 encrypted tunnel.
 
 ### Server data model (MVP)
 
+In memory (authoritative at runtime), mirrored row-by-row to SQLite:
+
 ```text
 PartyState { name, password: Option<String>, tier, members, channels, dm_threads,
-             persist_path }
-Member  { id, username, fingerprint: Option<String>, joined_at, online }
+             db: Option<Connection> }
+Member  { id, username, fingerprint: Option<String>, online }
 Channel { id, name, kind, messages: Vec<Envelope> }   # messages = durable history
 ```
 
+SQLite tables: `members`, `channels` (with a `position` column for stable
+ordering), `messages`, `dm_threads`, `dm_messages` (envelopes stored as JSON).
+
 ### What remains
 
-- Migrate the JSON snapshot to the **embedded SQLite** + filesystem blob store the
-  data model calls for (the snapshot shape maps cleanly to tables) — see §9.
+- The filesystem **blob store** for files (Phase 2) — the SQLite metadata store is
+  now in place (see §9).
 - A dedicated **TUI Party pane** (beyond command output) and **server-identity
   TOFU** confirmation UI in the GUI.
 - Roles/permissions, governance/audit, lock/password gating per channel (Phase 3);
@@ -276,9 +283,10 @@ Content-addressable, deduplicated storage:
 `Channel`, `Message(envelope)`, `DMThread`, `Blob`, `FileEntry`,
 `PermissionMatrix`, `FileReference`, `Quota`, `Role`, `Policy`, `AuditLog`.
 
-**Server persistence:** today an auto-saved **JSON snapshot** under the operator's
-data dir (interim). The target is embedded **SQLite** for metadata + a filesystem
-blob store, chosen for zero-ops single-host hosting with room to swap later.
+**Server persistence:** embedded **SQLite** (`party.db`) for metadata under the
+operator's data dir, with a filesystem blob store still to come for files
+(Phase 2), chosen for zero-ops single-host hosting with room to swap later. The
+former interim JSON snapshot is imported once on first load, then superseded.
 
 ---
 
@@ -432,7 +440,7 @@ Each phase gets its own detailed plan before code lands.
 
 ```text
 Phase 0  Workspace refactor                         ✅ done
-Phase 1  Party Server MVP (Administered)            ✅ core done · SQLite + UI polish remain
+Phase 1  Party Server MVP (Administered)            ✅ core + SQLite done · UI polish remains
 UI       Tauri + SolidJS rewrite (§10)              ▶ next major effort
 Phase 2  Drive / files
 Phase 3  Governance & roles
@@ -449,8 +457,9 @@ Independent:  P2P connection passwords + conversation lock   ✅ done
   join-by-address (+ optional password) + username, member directory + presence,
   channels, server-routed group + DM messaging, offline buffering via history
   catch-up, channel creation, the GUI Party window + TUI commands, server-identity
-  TOFU on the wire. **Remaining:** migrate the JSON snapshot to SQLite + blob
-  store; TUI Party pane; GUI server-TOFU/error polish (see §7).
+  TOFU on the wire, and SQLite-backed durable state (`party.db`). **Remaining:**
+  the filesystem blob store for files (Phase 2); TUI Party pane; GUI
+  server-TOFU/error polish (see §7).
 - **UI rewrite — Tauri + SolidJS.** The next major effort; full plan in §10. Plan
   a `2.0.0` release when Phase F lands (owner authorizes the tag).
 - **Phase 2 — Drive / files.** Upload/list/download/delete in channels & DMs; hash

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { workspace = true }
 rsa = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,29 +1,42 @@
-//! In-memory Party server state and the pure logic that drives it (Phase 1,
-//! slice 1).
+//! In-memory Party server state plus its durable backing store (Phase 1).
 //!
 //! This is the authoritative runtime model: members, channels, and durable
 //! per-channel message history (which is what makes offline buffering work in the
 //! Administered tier — a reconnecting member simply fetches history after the last
-//! sequence it saw). It is deliberately network-free so it can be unit-tested
-//! deterministically; the TCP/handshake runtime (slice 3) drives these methods.
+//! sequence it saw). The pure logic is deliberately network-free so it can be
+//! unit-tested deterministically; the TCP/handshake runtime drives these methods.
+//!
+//! ## Durability
+//!
+//! Runtime state is kept in memory for fast reads and is mirrored to an embedded
+//! **SQLite** database (`party.db`) under the operator's data dir. Each mutation
+//! writes its delta (a single row) rather than rewriting a whole snapshot, so cost
+//! scales with the change, not the history size. A server created with
+//! [`PartyState::new`] has no database and is purely in-memory (used by tests and
+//! by callers that manage their own persistence); [`PartyState::load`] opens the
+//! database, performs a one-time import of any legacy `party_state.json` snapshot,
+//! and reconstructs the in-memory model from the tables.
 
 // Several accessors and fields here (directory/channel listing, presence toggling,
 // the member fingerprint binding) are exercised by the tests now and consumed by
-// the network runtime in the next slice; allow them ahead of that wiring.
+// the network runtime; allow them ahead of that wiring.
 #![allow(dead_code)]
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use messenger_core::party::{
     ChannelInfo, ChannelKind, Envelope, MemberInfo, MessagePayload, TrustTier,
 };
 use messenger_core::util::current_timestamp_millis;
-use serde::{Deserialize, Serialize};
+use rusqlite::{params, Connection};
+use serde::Deserialize;
 use uuid::Uuid;
 
-/// Filename of the durable state snapshot under the operator's data dir.
-const SNAPSHOT_FILE: &str = "party_state.json";
+/// Filename of the embedded SQLite database under the operator's data dir.
+const DB_FILE: &str = "party.db";
+/// Filename of the legacy JSON snapshot, imported once into SQLite if present.
+const LEGACY_SNAPSHOT_FILE: &str = "party_state.json";
 
 /// Why a join was refused.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,17 +56,14 @@ impl JoinError {
     }
 }
 
-#[derive(Serialize, Deserialize)]
 struct Member {
     id: Uuid,
     username: String,
     fingerprint: Option<String>,
     /// Presence is runtime-only and not persisted; members start offline on load.
-    #[serde(skip)]
     online: bool,
 }
 
-#[derive(Serialize, Deserialize)]
 struct Channel {
     id: Uuid,
     name: String,
@@ -63,31 +73,44 @@ struct Channel {
 }
 
 /// A 1:1 direct-message thread, keyed by `messenger_core::party::dm_thread_id`.
-#[derive(Serialize, Deserialize)]
 struct DmThread {
     id: Uuid,
     messages: Vec<Envelope>,
 }
 
-/// Owned on-disk snapshot used when loading. Server name/password/tier come from
-/// configuration, not the snapshot.
+// --- Legacy JSON snapshot shapes (read-only, for one-time import) ---------------
+
+#[derive(Deserialize)]
+struct LegacyMember {
+    id: Uuid,
+    username: String,
+    fingerprint: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LegacyChannel {
+    id: Uuid,
+    name: String,
+    kind: ChannelKind,
+    messages: Vec<Envelope>,
+}
+
+#[derive(Deserialize)]
+struct LegacyDmThread {
+    id: Uuid,
+    messages: Vec<Envelope>,
+}
+
 #[derive(Deserialize, Default)]
-struct Snapshot {
-    members: Vec<Member>,
-    channels: Vec<Channel>,
+struct LegacySnapshot {
+    members: Vec<LegacyMember>,
+    channels: Vec<LegacyChannel>,
     #[serde(default)]
-    dm_threads: Vec<DmThread>,
+    dm_threads: Vec<LegacyDmThread>,
 }
 
-/// Borrowing view used when saving, to avoid cloning channel/DM history.
-#[derive(Serialize)]
-struct SnapshotRef<'a> {
-    members: Vec<&'a Member>,
-    channels: &'a [Channel],
-    dm_threads: Vec<&'a DmThread>,
-}
-
-/// The full server state.
+/// The full server state. Server name/password/tier come from configuration, not
+/// the store.
 pub struct PartyState {
     name: String,
     password: Option<String>,
@@ -96,12 +119,13 @@ pub struct PartyState {
     channels: Vec<Channel>,
     /// Direct-message threads, keyed by their deterministic thread id.
     dm_threads: HashMap<Uuid, DmThread>,
-    /// When set, mutations are persisted to this snapshot file.
-    persist_path: Option<PathBuf>,
+    /// When present, mutations are mirrored to this database.
+    db: Option<Connection>,
 }
 
 impl PartyState {
-    /// Create a new Administered server with a default `general` channel.
+    /// Create a new in-memory Administered server with a default `general` channel
+    /// and no durable backing store. Mutations are not persisted.
     pub fn new(name: impl Into<String>, password: Option<String>) -> Self {
         let general = Channel {
             id: Uuid::new_v4(),
@@ -116,57 +140,53 @@ impl PartyState {
             members: HashMap::new(),
             channels: vec![general],
             dm_threads: HashMap::new(),
-            persist_path: None,
+            db: None,
         }
     }
 
-    /// Load durable state from `<data_dir>/party_state.json`, or start fresh (with
-    /// a default `general` channel) if absent. Subsequent mutations auto-persist to
-    /// that file.
+    /// Open (creating if needed) the durable state in `<data_dir>/party.db`,
+    /// reconstructing the in-memory model from it. A fresh database is seeded with
+    /// the default `general` channel. If a legacy `party_state.json` snapshot is
+    /// present and the database is empty, it is imported once and then renamed to
+    /// `party_state.json.imported` so the import is not repeated. Subsequent
+    /// mutations auto-persist their delta.
     pub fn load(
         name: impl Into<String>,
         password: Option<String>,
         data_dir: &Path,
     ) -> anyhow::Result<Self> {
         std::fs::create_dir_all(data_dir)?;
-        let path = data_dir.join(SNAPSHOT_FILE);
+        let conn = Connection::open(data_dir.join(DB_FILE))?;
+        init_schema(&conn)?;
+
+        // One-time migration from the interim JSON snapshot into SQLite.
+        let legacy = data_dir.join(LEGACY_SNAPSHOT_FILE);
+        if legacy.exists() && db_is_empty(&conn)? {
+            import_legacy_snapshot(&conn, &legacy)?;
+            if let Err(e) = std::fs::rename(&legacy, data_dir.join("party_state.json.imported")) {
+                tracing::warn!(error = %e, "imported legacy snapshot but could not rename it; it will be ignored because the database is now non-empty");
+            }
+            tracing::info!("migrated legacy party_state.json snapshot into party.db");
+        }
+
         let mut state = Self::new(name, password);
+        state.db = Some(conn);
 
-        if path.exists() {
-            let json = std::fs::read_to_string(&path)?;
-            let snapshot: Snapshot = serde_json::from_str(&json)?;
-            state.members = snapshot.members.into_iter().map(|m| (m.id, m)).collect();
-            // Keep the default `general` channel if the snapshot has none.
-            if !snapshot.channels.is_empty() {
-                state.channels = snapshot.channels;
-            }
-            state.dm_threads = snapshot.dm_threads.into_iter().map(|t| (t.id, t)).collect();
+        if state.count_channels()? > 0 {
+            // The database is authoritative; rebuild the in-memory model from it.
+            state.reload_from_db()?;
+        } else {
+            // Fresh database: persist the seeded default `general` channel.
+            let general = &state.channels[0];
+            insert_channel_row(
+                state.db.as_ref().unwrap(),
+                general.id,
+                &general.name,
+                general.kind,
+                0,
+            )?;
         }
-
-        state.persist_path = Some(path);
         Ok(state)
-    }
-
-    /// Best-effort write of the durable state to the snapshot file (no-op when no
-    /// persist path is configured, e.g. in pure unit tests). Failures are logged
-    /// rather than propagated so a transient disk error doesn't drop a live request.
-    fn persist(&self) {
-        let Some(path) = &self.persist_path else {
-            return;
-        };
-        let snapshot = SnapshotRef {
-            members: self.members.values().collect(),
-            channels: &self.channels,
-            dm_threads: self.dm_threads.values().collect(),
-        };
-        match serde_json::to_string(&snapshot) {
-            Ok(json) => {
-                if let Err(e) = std::fs::write(path, json) {
-                    tracing::error!(error = %e, path = %path.display(), "failed to persist party state");
-                }
-            }
-            Err(e) => tracing::error!(error = %e, "failed to serialize party state"),
-        }
     }
 
     pub fn name(&self) -> &str {
@@ -206,20 +226,19 @@ impl PartyState {
         }
 
         let id = Uuid::new_v4();
-        self.members.insert(
+        let member = Member {
             id,
-            Member {
-                id,
-                username: username.to_string(),
-                fingerprint,
-                online: true,
-            },
-        );
-        self.persist();
+            username: username.to_string(),
+            fingerprint,
+            online: true,
+        };
+        self.persist_member(&member);
+        self.members.insert(id, member);
         Ok(id)
     }
 
     /// Mark a member's presence. Used when a connection drops or reconnects.
+    /// Presence is runtime-only and intentionally not persisted.
     pub fn set_online(&mut self, member: Uuid, online: bool) {
         if let Some(m) = self.members.get_mut(&member) {
             m.online = online;
@@ -270,6 +289,7 @@ impl PartyState {
         {
             return Err("a channel with that name already exists".to_string());
         }
+        let position = self.channels.len();
         let channel = Channel {
             id: Uuid::new_v4(),
             name: name.to_string(),
@@ -281,8 +301,8 @@ impl PartyState {
             name: channel.name.clone(),
             kind: channel.kind,
         };
+        self.persist_channel(&channel, position);
         self.channels.push(channel);
-        self.persist();
         Ok(info)
     }
 
@@ -322,7 +342,7 @@ impl PartyState {
             payload: MessagePayload::Text(text),
         };
         chan.messages.push(envelope.clone());
-        self.persist();
+        self.persist_message(&envelope);
         Ok(envelope)
     }
 
@@ -370,7 +390,7 @@ impl PartyState {
             payload: MessagePayload::Text(text),
         };
         thread.messages.push(envelope.clone());
-        self.persist();
+        self.persist_dm(thread_id, &envelope);
         Ok(envelope)
     }
 
@@ -386,6 +406,264 @@ impl PartyState {
             None => Vec::new(),
         }
     }
+
+    // --- Durable mirroring (best-effort: failures are logged, not propagated, so a
+    // transient disk error never drops a live request) --------------------------
+
+    fn persist_member(&self, m: &Member) {
+        let Some(conn) = &self.db else { return };
+        if let Err(e) = insert_member_row(conn, m.id, &m.username, m.fingerprint.as_deref()) {
+            tracing::error!(error = %e, "failed to persist party member");
+        }
+    }
+
+    fn persist_channel(&self, c: &Channel, position: usize) {
+        let Some(conn) = &self.db else { return };
+        if let Err(e) = insert_channel_row(conn, c.id, &c.name, c.kind, position) {
+            tracing::error!(error = %e, "failed to persist party channel");
+        }
+    }
+
+    fn persist_message(&self, e: &Envelope) {
+        let Some(conn) = &self.db else { return };
+        if let Err(e) = insert_message_row(conn, e) {
+            tracing::error!(error = %e, "failed to persist party message");
+        }
+    }
+
+    fn persist_dm(&self, thread_id: Uuid, e: &Envelope) {
+        let Some(conn) = &self.db else { return };
+        if let Err(e) = insert_dm_message_row(conn, thread_id, e) {
+            tracing::error!(error = %e, "failed to persist party direct message");
+        }
+    }
+
+    /// Rebuild the in-memory model from the database. Presence resets to offline.
+    fn reload_from_db(&mut self) -> anyhow::Result<()> {
+        let conn = self
+            .db
+            .as_ref()
+            .expect("reload_from_db requires an open database");
+
+        let mut members = HashMap::new();
+        {
+            let mut stmt = conn.prepare("SELECT id, username, fingerprint FROM members")?;
+            let rows = stmt.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, Option<String>>(2)?,
+                ))
+            })?;
+            for row in rows {
+                let (id, username, fingerprint) = row?;
+                let id = Uuid::parse_str(&id)?;
+                members.insert(
+                    id,
+                    Member {
+                        id,
+                        username,
+                        fingerprint,
+                        online: false,
+                    },
+                );
+            }
+        }
+
+        let mut channels = Vec::new();
+        {
+            let mut stmt =
+                conn.prepare("SELECT id, name, kind FROM channels ORDER BY position ASC")?;
+            let rows = stmt.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            })?;
+            let raw: Vec<(String, String, String)> = rows.collect::<Result<_, _>>()?;
+            for (id, name, kind) in raw {
+                let id = Uuid::parse_str(&id)?;
+                let kind: ChannelKind = serde_json::from_str(&kind)?;
+                let messages = load_messages(conn, "messages", "channel_id", id)?;
+                channels.push(Channel {
+                    id,
+                    name,
+                    kind,
+                    messages,
+                });
+            }
+        }
+
+        let mut dm_threads = HashMap::new();
+        {
+            let mut stmt = conn.prepare("SELECT id FROM dm_threads")?;
+            let ids: Vec<String> = stmt
+                .query_map([], |r| r.get::<_, String>(0))?
+                .collect::<Result<_, _>>()?;
+            for id in ids {
+                let id = Uuid::parse_str(&id)?;
+                let messages = load_messages(conn, "dm_messages", "thread_id", id)?;
+                dm_threads.insert(id, DmThread { id, messages });
+            }
+        }
+
+        self.members = members;
+        self.channels = channels;
+        self.dm_threads = dm_threads;
+        Ok(())
+    }
+}
+
+// --- Free-standing SQLite helpers ----------------------------------------------
+
+/// Create the schema if it does not yet exist.
+fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS members (
+             id          TEXT PRIMARY KEY,
+             username    TEXT NOT NULL,
+             fingerprint TEXT
+         );
+         CREATE TABLE IF NOT EXISTS channels (
+             id       TEXT PRIMARY KEY,
+             name     TEXT NOT NULL,
+             kind     TEXT NOT NULL,
+             position INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS messages (
+             channel_id TEXT NOT NULL,
+             seq        INTEGER NOT NULL,
+             envelope   TEXT NOT NULL,
+             PRIMARY KEY (channel_id, seq)
+         );
+         CREATE TABLE IF NOT EXISTS dm_threads (
+             id TEXT PRIMARY KEY
+         );
+         CREATE TABLE IF NOT EXISTS dm_messages (
+             thread_id TEXT NOT NULL,
+             seq       INTEGER NOT NULL,
+             envelope  TEXT NOT NULL,
+             PRIMARY KEY (thread_id, seq)
+         );",
+    )
+}
+
+/// True when no members, channels, or DM threads exist yet (a pristine database).
+fn db_is_empty(conn: &Connection) -> rusqlite::Result<bool> {
+    Ok(table_count(conn, "members")? == 0
+        && table_count(conn, "channels")? == 0
+        && table_count(conn, "dm_threads")? == 0)
+}
+
+fn table_count(conn: &Connection, table: &str) -> rusqlite::Result<i64> {
+    // `table` is a compile-time constant from this module, never user input.
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+}
+
+impl PartyState {
+    fn count_channels(&self) -> rusqlite::Result<i64> {
+        match &self.db {
+            Some(conn) => table_count(conn, "channels"),
+            None => Ok(0),
+        }
+    }
+}
+
+fn insert_member_row(
+    conn: &Connection,
+    id: Uuid,
+    username: &str,
+    fingerprint: Option<&str>,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO members (id, username, fingerprint) VALUES (?1, ?2, ?3)",
+        params![id.to_string(), username, fingerprint],
+    )?;
+    Ok(())
+}
+
+fn insert_channel_row(
+    conn: &Connection,
+    id: Uuid,
+    name: &str,
+    kind: ChannelKind,
+    position: usize,
+) -> rusqlite::Result<()> {
+    let kind = serde_json::to_string(&kind).expect("ChannelKind serializes");
+    conn.execute(
+        "INSERT OR REPLACE INTO channels (id, name, kind, position) VALUES (?1, ?2, ?3, ?4)",
+        params![id.to_string(), name, kind, position as i64],
+    )?;
+    Ok(())
+}
+
+fn insert_message_row(conn: &Connection, e: &Envelope) -> rusqlite::Result<()> {
+    let json = serde_json::to_string(e).expect("Envelope serializes");
+    conn.execute(
+        "INSERT OR REPLACE INTO messages (channel_id, seq, envelope) VALUES (?1, ?2, ?3)",
+        params![e.channel.to_string(), e.seq as i64, json],
+    )?;
+    Ok(())
+}
+
+fn insert_dm_message_row(conn: &Connection, thread_id: Uuid, e: &Envelope) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO dm_threads (id) VALUES (?1)",
+        params![thread_id.to_string()],
+    )?;
+    let json = serde_json::to_string(e).expect("Envelope serializes");
+    conn.execute(
+        "INSERT OR REPLACE INTO dm_messages (thread_id, seq, envelope) VALUES (?1, ?2, ?3)",
+        params![thread_id.to_string(), e.seq as i64, json],
+    )?;
+    Ok(())
+}
+
+/// Load and deserialize an ordered envelope history from `table` where the keying
+/// column `key_col` equals `key`. Both `table` and `key_col` are module constants.
+fn load_messages(
+    conn: &Connection,
+    table: &str,
+    key_col: &str,
+    key: Uuid,
+) -> anyhow::Result<Vec<Envelope>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT envelope FROM {table} WHERE {key_col} = ?1 ORDER BY seq ASC"
+    ))?;
+    let rows: Vec<String> = stmt
+        .query_map(params![key.to_string()], |r| r.get::<_, String>(0))?
+        .collect::<Result<_, _>>()?;
+    let mut out = Vec::with_capacity(rows.len());
+    for json in rows {
+        out.push(serde_json::from_str(&json)?);
+    }
+    Ok(out)
+}
+
+/// One-time import of a legacy JSON snapshot into the (empty) database, in a single
+/// transaction so it is all-or-nothing.
+fn import_legacy_snapshot(conn: &Connection, path: &Path) -> anyhow::Result<()> {
+    let json = std::fs::read_to_string(path)?;
+    let snap: LegacySnapshot = serde_json::from_str(&json)?;
+
+    let tx = conn.unchecked_transaction()?;
+    for m in &snap.members {
+        insert_member_row(&tx, m.id, &m.username, m.fingerprint.as_deref())?;
+    }
+    for (position, c) in snap.channels.iter().enumerate() {
+        insert_channel_row(&tx, c.id, &c.name, c.kind, position)?;
+        for e in &c.messages {
+            insert_message_row(&tx, e)?;
+        }
+    }
+    for t in &snap.dm_threads {
+        for e in &t.messages {
+            insert_dm_message_row(&tx, t.id, e)?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -505,7 +783,7 @@ mod tests {
             state
                 .post_message(alice, channel, "persisted msg".to_string())
                 .unwrap();
-        } // dropped; everything was written through to disk on each mutation
+        } // dropped; everything was written through to the database on each mutation
 
         let reloaded = PartyState::load("Srv", None, dir.path()).unwrap();
         // Member directory survived; presence resets to offline after reload.
@@ -586,5 +864,93 @@ mod tests {
         }
         let s = PartyState::load("Srv", None, dir.path()).unwrap();
         assert_eq!(s.dm_history(thread, 0).len(), 1);
+    }
+
+    #[test]
+    fn created_channels_and_their_order_persist_across_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let (general, random_id);
+        {
+            let mut s = PartyState::load("Srv", None, dir.path()).unwrap();
+            general = s.default_channel();
+            let alice = s.join("alice", None, None).unwrap();
+            random_id = s.create_channel("random").unwrap().id;
+            s.post_message(alice, random_id, "in random".to_string())
+                .unwrap();
+        }
+        let s = PartyState::load("Srv", None, dir.path()).unwrap();
+        let channels = s.channels();
+        assert_eq!(channels.len(), 2);
+        // Order is preserved: general first, then the created channel.
+        assert_eq!(s.default_channel(), general);
+        assert_eq!(channels[0].id, general);
+        assert_eq!(channels[1].id, random_id);
+        // History of the created channel survived.
+        let history = s.history_since(random_id, 0);
+        assert_eq!(history.len(), 1);
+        assert_eq!(
+            history[0].payload,
+            MessagePayload::Text("in random".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_json_snapshot_is_imported_once() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Hand-write a legacy snapshot in the old on-disk shape.
+        let member_id = Uuid::new_v4();
+        let channel_id = Uuid::new_v4();
+        let snapshot = serde_json::json!({
+            "members": [
+                { "id": member_id, "username": "legacy_user", "fingerprint": "FP" }
+            ],
+            "channels": [
+                {
+                    "id": channel_id,
+                    "name": "general",
+                    "kind": "Public",
+                    "messages": [
+                        {
+                            "tier": "Administered",
+                            "sender": member_id,
+                            "channel": channel_id,
+                            "seq": 1,
+                            "timestamp": 1700000000000u64,
+                            "payload": { "Text": "hello from the past" }
+                        }
+                    ]
+                }
+            ],
+            "dm_threads": []
+        });
+        std::fs::write(
+            dir.path().join("party_state.json"),
+            serde_json::to_string(&snapshot).unwrap(),
+        )
+        .unwrap();
+
+        // First load imports the snapshot into SQLite and renames the file.
+        let state = PartyState::load("Srv", None, dir.path()).unwrap();
+        assert_eq!(state.members().len(), 1);
+        assert_eq!(state.members()[0].username, "legacy_user");
+        assert_eq!(state.default_channel(), channel_id);
+        let history = state.history_since(channel_id, 0);
+        assert_eq!(history.len(), 1);
+        assert_eq!(
+            history[0].payload,
+            MessagePayload::Text("hello from the past".to_string())
+        );
+        assert!(
+            !dir.path().join("party_state.json").exists(),
+            "legacy snapshot should be renamed after import"
+        );
+        assert!(dir.path().join("party_state.json.imported").exists());
+
+        // A second load must not re-import (the database is now authoritative).
+        drop(state);
+        let reloaded = PartyState::load("Srv", None, dir.path()).unwrap();
+        assert_eq!(reloaded.members().len(), 1);
+        assert_eq!(reloaded.history_since(channel_id, 0).len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- Completes the first remaining **Phase 1** item: the Party server's durable state moves from a full-JSON-snapshot-per-mutation to an embedded **SQLite** database (`party.db`). The in-memory model and the entire `PartyState` public API are unchanged — only the durability backend swaps — so all existing logic and tests are preserved.
- Each mutation writes a single-row delta (cost scales with the change, not history size). Schema: `members`, `channels` (with `position` for stable ordering), `messages`, `dm_threads`, `dm_messages`; envelopes/kind stored as JSON.
- One-time migration: an existing `party_state.json` snapshot is imported in a single transaction on first load, then renamed to `.imported` so it never re-applies.
- Adds `rusqlite` with the `bundled` feature (compiles SQLite from source — no system dependency).
- Also fixes two regressions the earlier workspace merge left on `main`: CI never installed the Tauri crate's WebKitGTK system deps (so `cargo clippy/test/build --workspace` failed on `desktop/src-tauri`), and that crate hadn't been run through `rustfmt` (breaking `cargo fmt --all --check`).
- Cuts the **v1.10.1** release (version bump + dated CHANGELOG).

## User Impact

- **Operators:** no configuration change. The server now keeps state in `party.db`; an existing `party_state.json` is migrated automatically on first start. Persistence is incremental, so busy servers no longer rewrite the full history on every message.
- **Release/CI:** the full workspace now builds in CI (Tauri deps installed); `cargo fmt --all --check` passes again.

## Verification

- [x] `cargo test -p messenger-server` — 32/32 pass (incl. new channel-ordering-across-reload and legacy-import tests; existing reload tests now exercise SQLite)
- [x] `cargo test -p messenger-core -p encodeur_rsa_rust` — all pass (94 core + 72 client + integration suites)
- [x] `cargo clippy -p messenger-server --all-targets` — clean
- [x] `cargo build -p messenger-server --locked` — clean
- [ ] `cargo fmt --all -- --check` / workspace clippy/build — verified the inputs locally, but the Tauri crate's native deps aren't installable in my sandbox; relying on CI to confirm the full `--workspace` gates with the new deps step

## Docs And Release Notes

- [x] Platform spec (§7, §9, §11 roadmap) and architecture doc updated to record SQLite shipping and mark the Phase 1 item complete
- [x] `CHANGELOG.md` updated with the `[1.10.1]` entry
- [x] No protocol/wire change — the durability backend is internal to the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6VnUASevg4rszRpyNTFUz)_