### PR TITLE
feat(party): content-addressed file sharing in channels and DMs (Phase 2, slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **File sharing in Party servers (Phase 2, slice 1).** Members can share files
+  (up to 4 MiB inline) in channels and direct messages. The server stores each
+  file once, content-addressed by SHA-256 and reference-counted, with the bytes on
+  disk and metadata in the SQLite store; a file appears in history like a message
+  and can be fetched by hash. Larger-file chunking and the Drive UI are still to
+  come.
+
 ## [1.10.1] - 2026-06-28
 
 ### Changed

--- a/client/src/app/party_manager.rs
+++ b/client/src/app/party_manager.rs
@@ -316,6 +316,8 @@ fn apply(conn: &mut PartyServerConn, resp: PartyResponse) {
         }
         // Ack carries no content; the optimistic local append already happened.
         PartyResponse::MessagePosted { .. } => {}
+        // Downloaded file bytes; surfacing/saving them in the UI is a follow-up slice.
+        PartyResponse::FileData { .. } => {}
         PartyResponse::Error(_) => {}
     }
 }

--- a/client/src/gui/party_view.rs
+++ b/client/src/gui/party_view.rs
@@ -352,8 +352,13 @@ fn snapshot(app: &App) -> Option<Snapshot> {
                     let rendered = msgs
                         .iter()
                         .map(|env| {
-                            let MessagePayload::Text(t) = &env.payload;
-                            (env.sender, t.clone())
+                            let text = match &env.payload {
+                                MessagePayload::Text(t) => t.clone(),
+                                MessagePayload::File(f) => {
+                                    format!("📎 {} ({} bytes)", f.name, f.size)
+                                }
+                            };
+                            (env.sender, text)
                         })
                         .collect::<Vec<_>>();
                     (*ch, rendered)

--- a/core/src/party/mod.rs
+++ b/core/src/party/mod.rs
@@ -31,11 +31,40 @@ pub enum TrustTier {
     E2EE,
 }
 
+/// Maximum size of a file uploaded inline in a single Party request (Phase 2,
+/// slice 1). Larger files will use chunked transfer in a later slice. Kept well
+/// under [`crate::MAX_PACKET_SIZE`] to leave headroom for request framing.
+pub const MAX_INLINE_FILE_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
+
+/// Metadata describing a file shared in a channel or DM. The file's bytes are
+/// stored content-addressed by `hash` (lowercase hex SHA-256); `name` is the
+/// per-message display name, so two messages may reference one blob under
+/// different names.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileMeta {
+    pub hash: String,
+    pub name: String,
+    pub size: u64,
+    pub mime: String,
+}
+
 /// The application payload carried by an [`Envelope`]. For the Administered tier
 /// this is plaintext; the E2EE tier (Phase 4) will add a ciphertext variant.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MessagePayload {
     Text(String),
+    /// A reference to a file stored on the server (Phase 2). The bytes are fetched
+    /// separately via [`PartyRequest::DownloadFile`] using `FileMeta::hash`.
+    File(FileMeta),
+}
+
+/// Content address (lowercase hex SHA-256) of a blob's bytes. Both sides compute
+/// this identically so uploads can be deduplicated by content.
+pub fn blob_hash(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex::encode(hasher.finalize())
 }
 
 /// A single stored/transported message. One data model across both tiers.
@@ -102,6 +131,23 @@ pub enum PartyRequest {
     FetchDmHistory { with: Uuid, since_seq: u64 },
     /// Create a new public channel.
     CreateChannel { name: String },
+    /// Upload a file inline and post it as a message to a channel. The bytes must
+    /// not exceed [`MAX_INLINE_FILE_BYTES`].
+    PostFile {
+        channel: Uuid,
+        name: String,
+        mime: String,
+        data: Vec<u8>,
+    },
+    /// Upload a file inline and send it as a direct message to another member.
+    SendFileDm {
+        to: Uuid,
+        name: String,
+        mime: String,
+        data: Vec<u8>,
+    },
+    /// Fetch a stored file's bytes by its content hash.
+    DownloadFile { hash: String },
 }
 
 /// Deterministic, order-independent id for the 1:1 DM thread between two members,
@@ -145,6 +191,11 @@ pub enum PartyResponse {
     Message(Envelope),
     /// A batch of history items (response to `FetchHistory`).
     History(Vec<Envelope>),
+    /// A stored file's bytes (response to `DownloadFile`).
+    FileData {
+        hash: String,
+        data: Vec<u8>,
+    },
     /// A non-fatal application error.
     Error(String),
 }
@@ -388,11 +439,56 @@ mod tests {
             PartyRequest::CreateChannel {
                 name: "random".to_string(),
             },
+            PartyRequest::PostFile {
+                channel: Uuid::new_v4(),
+                name: "report.pdf".to_string(),
+                mime: "application/pdf".to_string(),
+                data: vec![1, 2, 3, 4],
+            },
+            PartyRequest::SendFileDm {
+                to: Uuid::new_v4(),
+                name: "note.txt".to_string(),
+                mime: "text/plain".to_string(),
+                data: b"hi".to_vec(),
+            },
+            PartyRequest::DownloadFile {
+                hash: "abc123".to_string(),
+            },
         ];
         for req in requests {
             let bytes = req.to_bytes();
             assert_eq!(PartyRequest::from_bytes(&bytes), Some(req));
         }
+    }
+
+    #[test]
+    fn blob_hash_is_deterministic_and_content_addressed() {
+        assert_eq!(blob_hash(b"hello"), blob_hash(b"hello"));
+        assert_ne!(blob_hash(b"hello"), blob_hash(b"world"));
+        // Known SHA-256 of "hello" (lowercase hex).
+        assert_eq!(
+            blob_hash(b"hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn file_payload_envelope_roundtrips() {
+        let env = Envelope {
+            tier: TrustTier::Administered,
+            sender: Uuid::new_v4(),
+            channel: Uuid::new_v4(),
+            seq: 7,
+            timestamp: 1234,
+            payload: MessagePayload::File(FileMeta {
+                hash: blob_hash(b"data"),
+                name: "f.bin".to_string(),
+                size: 4,
+                mime: "application/octet-stream".to_string(),
+            }),
+        };
+        let bytes = bincode::serialize(&env).unwrap();
+        assert_eq!(bincode::deserialize::<Envelope>(&bytes).unwrap(), env);
     }
 
     #[test]
@@ -439,6 +535,10 @@ mod tests {
             },
             PartyResponse::Message(sample_envelope()),
             PartyResponse::History(vec![sample_envelope(), sample_envelope()]),
+            PartyResponse::FileData {
+                hash: blob_hash(b"bytes"),
+                data: b"bytes".to_vec(),
+            },
             PartyResponse::Error("boom".to_string()),
         ];
         for resp in responses {

--- a/docs/05_platform_spec.md
+++ b/docs/05_platform_spec.md
@@ -258,7 +258,18 @@ ordering), `messages`, `dm_threads`, `dm_messages` (envelopes stored as JSON).
 
 ## 8. Files / "Drive" (Phase 2)
 
-Content-addressable, deduplicated storage:
+**Shipped (slice 1):** content-addressed inline file sharing in the Party server.
+A `MessagePayload::File(FileMeta)` carries a file reference in channel and DM
+history; `PartyRequest::PostFile` / `SendFileDm` upload bytes inline (bounded by
+`MAX_INLINE_FILE_BYTES = 4 MiB`) and post a file message that broadcasts like a
+text message; `DownloadFile { hash }` returns the bytes. The server stores each
+blob once, keyed by SHA-256, reference-counted, with the bytes on disk under
+`<data_dir>/blobs/<hash>` and metadata (`hash, size, mime, refcount`) in the
+`blobs` SQLite table. **Remaining:** chunked transfer for large files; the
+permission matrix, quotas, provenance, and the Drive UI panel below; client-side
+download/save wiring.
+
+Target data model — content-addressable, deduplicated storage:
 
 - **Blob** — raw content stored once: `hash, size, mime, (ciphertext?)`.
 - **FileEntry** — a logical file in the UI: `name, owner, server, location, date,
@@ -442,7 +453,7 @@ Each phase gets its own detailed plan before code lands.
 Phase 0  Workspace refactor                         ✅ done
 Phase 1  Party Server MVP (Administered)            ✅ core + SQLite done · UI polish remains
 UI       Tauri + SolidJS rewrite (§10)              ▶ next major effort
-Phase 2  Drive / files
+Phase 2  Drive / files                              ◐ slice 1 (inline file sharing) done
 Phase 3  Governance & roles
 Phase 4  E2EE server tier
 Phase 5  Per-server identities
@@ -462,8 +473,10 @@ Independent:  P2P connection passwords + conversation lock   ✅ done
   server-TOFU/error polish (see §7).
 - **UI rewrite — Tauri + SolidJS.** The next major effort; full plan in §10. Plan
   a `2.0.0` release when Phase F lands (owner authorizes the tag).
-- **Phase 2 — Drive / files.** Upload/list/download/delete in channels & DMs; hash
-  dedup + reference counting; logical + physical quotas; the Drive panel.
+- **Phase 2 — Drive / files. ◐ slice 1 done.** Inline (≤4 MiB) content-addressed
+  file sharing in channels & DMs with hash dedup + reference counting and on-disk
+  blobs landed (see §8). Remaining: chunked transfer for large files,
+  list/download/delete UX, logical + physical quotas, and the Drive panel.
 - **Phase 3 — Governance & roles.** Trust-tier labeling, transparency panel,
   consent-or-leave, audit log, roles/permissions, visibility & contact policies,
   channel lock/password.

--- a/server/src/dispatch.rs
+++ b/server/src/dispatch.rs
@@ -146,6 +146,44 @@ pub fn handle_request(state: &mut PartyState, conn: &mut ConnState, req: PartyRe
                     let thread = messenger_core::party::dm_thread_id(member, with);
                     Dispatch::reply(PartyResponse::History(state.dm_history(thread, since_seq)))
                 }
+                PartyRequest::PostFile {
+                    channel,
+                    name,
+                    mime,
+                    data,
+                } => match state.post_file(member, channel, name, mime, data) {
+                    // Like PostMessage: ack the poster, broadcast the file message.
+                    Ok(env) => Dispatch {
+                        replies: vec![PartyResponse::MessagePosted {
+                            channel: env.channel,
+                            seq: env.seq,
+                        }],
+                        broadcast: vec![PartyResponse::Message(env)],
+                        directed: Vec::new(),
+                    },
+                    Err(e) => Dispatch::reply(PartyResponse::Error(e)),
+                },
+                PartyRequest::SendFileDm {
+                    to,
+                    name,
+                    mime,
+                    data,
+                } => match state.post_file_dm(member, to, name, mime, data) {
+                    // Like SendDm: ack the sender, deliver to the recipient.
+                    Ok(env) => Dispatch {
+                        replies: vec![PartyResponse::MessagePosted {
+                            channel: env.channel,
+                            seq: env.seq,
+                        }],
+                        broadcast: Vec::new(),
+                        directed: vec![(to, PartyResponse::Message(env))],
+                    },
+                    Err(e) => Dispatch::reply(PartyResponse::Error(e)),
+                },
+                PartyRequest::DownloadFile { hash } => match state.blob_bytes(&hash) {
+                    Some(data) => Dispatch::reply(PartyResponse::FileData { hash, data }),
+                    None => Dispatch::reply(PartyResponse::Error("unknown file".to_string())),
+                },
             }
         }
     }
@@ -326,5 +364,74 @@ mod tests {
             },
         );
         assert!(matches!(&out.replies[..], [PartyResponse::Error(m)] if m == "join required"));
+    }
+
+    #[test]
+    fn post_file_acks_the_poster_and_broadcasts_a_file_message() {
+        let mut state = PartyState::new("Srv", None);
+        let mut conn = ConnState::default();
+        join(&mut state, &mut conn, "alice", None);
+        let channel = state.default_channel();
+
+        let out = handle_request(
+            &mut state,
+            &mut conn,
+            PartyRequest::PostFile {
+                channel,
+                name: "pic.png".to_string(),
+                mime: "image/png".to_string(),
+                data: b"\x89PNG data".to_vec(),
+            },
+        );
+        assert!(matches!(
+            &out.replies[..],
+            [PartyResponse::MessagePosted { .. }]
+        ));
+        match &out.broadcast[..] {
+            [PartyResponse::Message(env)] => {
+                assert!(matches!(&env.payload, MessagePayload::File(f) if f.name == "pic.png"));
+            }
+            other => panic!("expected a broadcast File message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn download_returns_bytes_for_known_and_errors_for_unknown() {
+        let mut state = PartyState::new("Srv", None);
+        let mut conn = ConnState::default();
+        join(&mut state, &mut conn, "alice", None);
+        let channel = state.default_channel();
+
+        let post = handle_request(
+            &mut state,
+            &mut conn,
+            PartyRequest::PostFile {
+                channel,
+                name: "f.bin".to_string(),
+                mime: "application/octet-stream".to_string(),
+                data: b"payload".to_vec(),
+            },
+        );
+        let hash = match &post.broadcast[..] {
+            [PartyResponse::Message(env)] => match &env.payload {
+                MessagePayload::File(f) => f.hash.clone(),
+                other => panic!("expected File payload, got {other:?}"),
+            },
+            other => panic!("expected broadcast, got {other:?}"),
+        };
+
+        let ok = handle_request(&mut state, &mut conn, PartyRequest::DownloadFile { hash });
+        assert!(
+            matches!(&ok.replies[..], [PartyResponse::FileData { data, .. }] if data == b"payload")
+        );
+
+        let missing = handle_request(
+            &mut state,
+            &mut conn,
+            PartyRequest::DownloadFile {
+                hash: "deadbeef".to_string(),
+            },
+        );
+        assert!(matches!(&missing.replies[..], [PartyResponse::Error(_)]));
     }
 }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -23,10 +23,11 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use messenger_core::party::{
-    ChannelInfo, ChannelKind, Envelope, MemberInfo, MessagePayload, TrustTier,
+    blob_hash, ChannelInfo, ChannelKind, Envelope, FileMeta, MemberInfo, MessagePayload, TrustTier,
+    MAX_INLINE_FILE_BYTES,
 };
 use messenger_core::util::current_timestamp_millis;
 use rusqlite::{params, Connection};
@@ -35,6 +36,8 @@ use uuid::Uuid;
 
 /// Filename of the embedded SQLite database under the operator's data dir.
 const DB_FILE: &str = "party.db";
+/// Subdirectory under the data dir holding content-addressed file blobs.
+const BLOB_DIR: &str = "blobs";
 /// Filename of the legacy JSON snapshot, imported once into SQLite if present.
 const LEGACY_SNAPSHOT_FILE: &str = "party_state.json";
 
@@ -78,6 +81,16 @@ struct DmThread {
     messages: Vec<Envelope>,
 }
 
+/// A content-addressed file blob. The bytes are deduplicated by content hash and
+/// reference-counted (each message that references the blob holds one count); the
+/// bytes also live on disk under `<data_dir>/blobs/<hash>`.
+struct BlobRecord {
+    size: u64,
+    mime: String,
+    data: Vec<u8>,
+    refcount: u32,
+}
+
 // --- Legacy JSON snapshot shapes (read-only, for one-time import) ---------------
 
 #[derive(Deserialize)]
@@ -119,8 +132,12 @@ pub struct PartyState {
     channels: Vec<Channel>,
     /// Direct-message threads, keyed by their deterministic thread id.
     dm_threads: HashMap<Uuid, DmThread>,
+    /// Content-addressed file blobs, keyed by hex SHA-256 of their bytes.
+    blobs: HashMap<String, BlobRecord>,
     /// When present, mutations are mirrored to this database.
     db: Option<Connection>,
+    /// When present, blob bytes are mirrored to files under this directory.
+    blob_dir: Option<PathBuf>,
 }
 
 impl PartyState {
@@ -140,7 +157,9 @@ impl PartyState {
             members: HashMap::new(),
             channels: vec![general],
             dm_threads: HashMap::new(),
+            blobs: HashMap::new(),
             db: None,
+            blob_dir: None,
         }
     }
 
@@ -156,6 +175,8 @@ impl PartyState {
         data_dir: &Path,
     ) -> anyhow::Result<Self> {
         std::fs::create_dir_all(data_dir)?;
+        let blob_dir = data_dir.join(BLOB_DIR);
+        std::fs::create_dir_all(&blob_dir)?;
         let conn = Connection::open(data_dir.join(DB_FILE))?;
         init_schema(&conn)?;
 
@@ -171,6 +192,7 @@ impl PartyState {
 
         let mut state = Self::new(name, password);
         state.db = Some(conn);
+        state.blob_dir = Some(blob_dir);
 
         if state.count_channels()? > 0 {
             // The database is authoritative; rebuild the in-memory model from it.
@@ -407,6 +429,136 @@ impl PartyState {
         }
     }
 
+    // --- File sharing (Phase 2, slice 1) ----------------------------------------
+
+    /// Store `data` as a content-addressed blob (deduplicated by hash, with the
+    /// bytes mirrored to disk) and return its [`FileMeta`]. A repeated upload of the
+    /// same content reuses the existing blob and bumps its reference count.
+    fn store_blob(&mut self, name: &str, mime: &str, data: Vec<u8>) -> FileMeta {
+        let hash = blob_hash(&data);
+        let size = data.len() as u64;
+        if let Some(rec) = self.blobs.get_mut(&hash) {
+            rec.refcount += 1;
+            let refcount = rec.refcount;
+            self.persist_blob_refcount(&hash, refcount);
+        } else {
+            self.write_blob_file(&hash, &data);
+            self.persist_blob_row(&hash, size, mime, 1);
+            self.blobs.insert(
+                hash.clone(),
+                BlobRecord {
+                    size,
+                    mime: mime.to_string(),
+                    data,
+                    refcount: 1,
+                },
+            );
+        }
+        FileMeta {
+            hash,
+            name: name.to_string(),
+            size,
+            mime: mime.to_string(),
+        }
+    }
+
+    /// Validate an inline upload's size, returning the data on success.
+    fn check_inline_size(data: Vec<u8>) -> Result<Vec<u8>, String> {
+        if data.is_empty() {
+            return Err("file is empty".to_string());
+        }
+        if data.len() > MAX_INLINE_FILE_BYTES {
+            return Err(format!(
+                "file exceeds the {} MiB inline limit",
+                MAX_INLINE_FILE_BYTES / (1024 * 1024)
+            ));
+        }
+        Ok(data)
+    }
+
+    /// Store a file and post it as a message to `channel`. Returns the assigned
+    /// envelope (its payload is `File`) for broadcast, like [`Self::post_message`].
+    pub fn post_file(
+        &mut self,
+        sender: Uuid,
+        channel: Uuid,
+        name: String,
+        mime: String,
+        data: Vec<u8>,
+    ) -> Result<Envelope, String> {
+        if !self.is_member(sender) {
+            return Err("sender is not a member of this server".to_string());
+        }
+        if self.channel(channel).is_none() {
+            return Err("unknown channel".to_string());
+        }
+        let data = Self::check_inline_size(data)?;
+        let tier = self.tier;
+        let meta = self.store_blob(&name, &mime, data);
+        // Re-borrow the channel after the blob store to append the message.
+        let chan = self
+            .channel_mut(channel)
+            .expect("channel existence checked");
+        let seq = chan.messages.len() as u64 + 1;
+        let envelope = Envelope {
+            tier,
+            sender,
+            channel,
+            seq,
+            timestamp: current_timestamp_millis(),
+            payload: MessagePayload::File(meta),
+        };
+        chan.messages.push(envelope.clone());
+        self.persist_message(&envelope);
+        Ok(envelope)
+    }
+
+    /// Store a file and send it as a direct message to `to`. Returns the assigned
+    /// envelope (payload `File`) for delivery, like [`Self::post_dm`].
+    pub fn post_file_dm(
+        &mut self,
+        from: Uuid,
+        to: Uuid,
+        name: String,
+        mime: String,
+        data: Vec<u8>,
+    ) -> Result<Envelope, String> {
+        if !self.is_member(from) {
+            return Err("sender is not a member of this server".to_string());
+        }
+        if !self.is_member(to) {
+            return Err("recipient is not a member of this server".to_string());
+        }
+        let data = Self::check_inline_size(data)?;
+        let thread_id = messenger_core::party::dm_thread_id(from, to);
+        let tier = self.tier;
+        let meta = self.store_blob(&name, &mime, data);
+        let thread = self
+            .dm_threads
+            .entry(thread_id)
+            .or_insert_with(|| DmThread {
+                id: thread_id,
+                messages: Vec::new(),
+            });
+        let seq = thread.messages.len() as u64 + 1;
+        let envelope = Envelope {
+            tier,
+            sender: from,
+            channel: thread_id,
+            seq,
+            timestamp: current_timestamp_millis(),
+            payload: MessagePayload::File(meta),
+        };
+        thread.messages.push(envelope.clone());
+        self.persist_dm(thread_id, &envelope);
+        Ok(envelope)
+    }
+
+    /// The bytes of a stored blob by content hash, or `None` if unknown.
+    pub fn blob_bytes(&self, hash: &str) -> Option<Vec<u8>> {
+        self.blobs.get(hash).map(|r| r.data.clone())
+    }
+
     // --- Durable mirroring (best-effort: failures are logged, not propagated, so a
     // transient disk error never drops a live request) --------------------------
 
@@ -435,6 +587,31 @@ impl PartyState {
         let Some(conn) = &self.db else { return };
         if let Err(e) = insert_dm_message_row(conn, thread_id, e) {
             tracing::error!(error = %e, "failed to persist party direct message");
+        }
+    }
+
+    fn write_blob_file(&self, hash: &str, data: &[u8]) {
+        let Some(dir) = &self.blob_dir else { return };
+        let path = dir.join(hash);
+        if let Err(e) = std::fs::write(&path, data) {
+            tracing::error!(error = %e, path = %path.display(), "failed to write file blob");
+        }
+    }
+
+    fn persist_blob_row(&self, hash: &str, size: u64, mime: &str, refcount: u32) {
+        let Some(conn) = &self.db else { return };
+        if let Err(e) = insert_blob_row(conn, hash, size, mime, refcount) {
+            tracing::error!(error = %e, "failed to persist file blob row");
+        }
+    }
+
+    fn persist_blob_refcount(&self, hash: &str, refcount: u32) {
+        let Some(conn) = &self.db else { return };
+        if let Err(e) = conn.execute(
+            "UPDATE blobs SET refcount = ?1 WHERE hash = ?2",
+            params![refcount, hash],
+        ) {
+            tracing::error!(error = %e, "failed to update file blob refcount");
         }
     }
 
@@ -508,9 +685,46 @@ impl PartyState {
             }
         }
 
+        let mut blobs = HashMap::new();
+        {
+            let mut stmt = conn.prepare("SELECT hash, size, mime, refcount FROM blobs")?;
+            let rows = stmt.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, i64>(3)?,
+                ))
+            })?;
+            let raw: Vec<(String, i64, String, i64)> = rows.collect::<Result<_, _>>()?;
+            let blob_dir = self
+                .blob_dir
+                .as_ref()
+                .expect("reload_from_db requires a blob directory");
+            for (hash, size, mime, refcount) in raw {
+                match std::fs::read(blob_dir.join(&hash)) {
+                    Ok(data) => {
+                        blobs.insert(
+                            hash,
+                            BlobRecord {
+                                size: size as u64,
+                                mime,
+                                data,
+                                refcount: refcount as u32,
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, hash = %hash, "blob bytes missing on disk; skipping")
+                    }
+                }
+            }
+        }
+
         self.members = members;
         self.channels = channels;
         self.dm_threads = dm_threads;
+        self.blobs = blobs;
         Ok(())
     }
 }
@@ -545,8 +759,28 @@ fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
              seq       INTEGER NOT NULL,
              envelope  TEXT NOT NULL,
              PRIMARY KEY (thread_id, seq)
+         );
+         CREATE TABLE IF NOT EXISTS blobs (
+             hash     TEXT PRIMARY KEY,
+             size     INTEGER NOT NULL,
+             mime     TEXT NOT NULL,
+             refcount INTEGER NOT NULL
          );",
     )
+}
+
+fn insert_blob_row(
+    conn: &Connection,
+    hash: &str,
+    size: u64,
+    mime: &str,
+    refcount: u32,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO blobs (hash, size, mime, refcount) VALUES (?1, ?2, ?3, ?4)",
+        params![hash, size as i64, mime, refcount],
+    )?;
+    Ok(())
 }
 
 /// True when no members, channels, or DM threads exist yet (a pristine database).
@@ -952,5 +1186,174 @@ mod tests {
         let reloaded = PartyState::load("Srv", None, dir.path()).unwrap();
         assert_eq!(reloaded.members().len(), 1);
         assert_eq!(reloaded.history_since(channel_id, 0).len(), 1);
+    }
+
+    fn file_payload(env: &Envelope) -> &FileMeta {
+        match &env.payload {
+            MessagePayload::File(f) => f,
+            other => panic!("expected a File payload, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn post_file_stores_blob_and_posts_a_file_message() {
+        let mut state = PartyState::new("Open", None);
+        let alice = state.join("alice", None, None).unwrap();
+        let chan = state.default_channel();
+
+        let env = state
+            .post_file(
+                alice,
+                chan,
+                "hi.txt".into(),
+                "text/plain".into(),
+                b"hello".to_vec(),
+            )
+            .expect("post_file");
+        assert_eq!(env.seq, 1);
+        let meta = file_payload(&env);
+        assert_eq!(meta.name, "hi.txt");
+        assert_eq!(meta.size, 5);
+        assert_eq!(meta.hash, blob_hash(b"hello"));
+
+        // The bytes are retrievable by hash, and the message is in channel history.
+        assert_eq!(state.blob_bytes(&meta.hash), Some(b"hello".to_vec()));
+        assert_eq!(state.history_since(chan, 0).len(), 1);
+    }
+
+    #[test]
+    fn identical_uploads_are_deduplicated_by_content() {
+        let mut state = PartyState::new("Open", None);
+        let alice = state.join("alice", None, None).unwrap();
+        let chan = state.default_channel();
+
+        let a = state
+            .post_file(
+                alice,
+                chan,
+                "a.bin".into(),
+                "application/octet-stream".into(),
+                b"same".to_vec(),
+            )
+            .unwrap();
+        let b = state
+            .post_file(
+                alice,
+                chan,
+                "b.bin".into(),
+                "application/octet-stream".into(),
+                b"same".to_vec(),
+            )
+            .unwrap();
+
+        // Two messages, two names, but one shared content-addressed blob.
+        assert_eq!(file_payload(&a).hash, file_payload(&b).hash);
+        assert_eq!(state.blobs.len(), 1);
+        assert_eq!(state.blobs[&file_payload(&a).hash].refcount, 2);
+        assert_eq!(state.history_since(chan, 0).len(), 2);
+    }
+
+    #[test]
+    fn oversized_and_empty_uploads_are_rejected() {
+        let mut state = PartyState::new("Open", None);
+        let alice = state.join("alice", None, None).unwrap();
+        let chan = state.default_channel();
+
+        assert!(state
+            .post_file(alice, chan, "empty".into(), "text/plain".into(), Vec::new())
+            .is_err());
+        let too_big = vec![0u8; MAX_INLINE_FILE_BYTES + 1];
+        assert!(state
+            .post_file(
+                alice,
+                chan,
+                "big".into(),
+                "application/octet-stream".into(),
+                too_big
+            )
+            .is_err());
+        // Nothing was stored.
+        assert!(state.blobs.is_empty());
+        assert!(state.history_since(chan, 0).is_empty());
+    }
+
+    #[test]
+    fn post_file_rejects_non_members_and_unknown_channels() {
+        let mut state = PartyState::new("Open", None);
+        let stranger = Uuid::new_v4();
+        let chan = state.default_channel();
+        assert!(state
+            .post_file(
+                stranger,
+                chan,
+                "x".into(),
+                "text/plain".into(),
+                b"x".to_vec()
+            )
+            .is_err());
+
+        let alice = state.join("alice", None, None).unwrap();
+        assert!(state
+            .post_file(
+                alice,
+                Uuid::new_v4(),
+                "x".into(),
+                "text/plain".into(),
+                b"x".to_vec()
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn file_dm_is_stored_in_the_thread() {
+        let mut state = PartyState::new("Open", None);
+        let alice = state.join("alice", None, None).unwrap();
+        let bob = state.join("bob", None, None).unwrap();
+        let thread = messenger_core::party::dm_thread_id(alice, bob);
+
+        let env = state
+            .post_file_dm(
+                alice,
+                bob,
+                "secret.txt".into(),
+                "text/plain".into(),
+                b"psst".to_vec(),
+            )
+            .expect("post_file_dm");
+        assert_eq!(env.channel, thread);
+        assert_eq!(file_payload(&env).name, "secret.txt");
+        assert_eq!(state.dm_history(thread, 0).len(), 1);
+        assert_eq!(
+            state.blob_bytes(&file_payload(&env).hash),
+            Some(b"psst".to_vec())
+        );
+    }
+
+    #[test]
+    fn blobs_and_file_messages_persist_across_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let (chan, hash);
+        {
+            let mut s = PartyState::load("Srv", None, dir.path()).unwrap();
+            chan = s.default_channel();
+            let alice = s.join("alice", None, None).unwrap();
+            let env = s
+                .post_file(
+                    alice,
+                    chan,
+                    "doc.txt".into(),
+                    "text/plain".into(),
+                    b"durable".to_vec(),
+                )
+                .unwrap();
+            hash = file_payload(&env).hash.clone();
+        }
+        let s = PartyState::load("Srv", None, dir.path()).unwrap();
+        // The blob bytes and the file message both survived.
+        assert_eq!(s.blob_bytes(&hash), Some(b"durable".to_vec()));
+        let history = s.history_since(chan, 0);
+        assert_eq!(history.len(), 1);
+        assert_eq!(file_payload(&history[0]).name, "doc.txt");
+        assert_eq!(s.blobs[&hash].refcount, 1);
     }
 }


### PR DESCRIPTION
## Summary

- Starts **Phase 2 (Drive / files)** with slice 1: members can share files inline (≤ 4 MiB) in Party channels and DMs, building directly on the SQLite store from 1.10.1.
- **Protocol (`core::party`):** `FileMeta { hash, name, size, mime }` and a new `MessagePayload::File` variant so a file reference rides in channel/DM history like a text message; `PartyRequest::PostFile` / `SendFileDm` (inline upload + post) and `DownloadFile { hash }`; `PartyResponse::FileData { hash, data }`; plus `blob_hash()` (SHA-256 hex) and `MAX_INLINE_FILE_BYTES`, shared by both sides.
- **Server:** a content-addressed blob store — bytes deduplicated by hash and reference-counted, persisted to `<data_dir>/blobs/<hash>` with a `blobs` SQLite table (`hash, size, mime, refcount`), reconstructed on reload. `post_file` / `post_file_dm` / `blob_bytes` with empty/oversize rejection; file messages broadcast (channel) or are directed (DM) exactly like text, so existing fan-out and offline catch-up cover them. Dispatch wires the three new requests.
- **Client:** keeps compiling and rendering — the egui Party view shows file messages as `📎 name (size)`; the `FileData` response is accepted (download-to-disk UX is an explicit follow-up).

## User Impact

- Party members can attach files to channel and DM conversations; recipients (including those who were offline) see them in history and can fetch the bytes by hash.
- Storage is dedup-aware: identical uploads are stored once and reference-counted. No operator configuration; blobs live alongside `party.db` under the data dir.
- Enum additions are backward-compatible with existing stored history (`Text` is unchanged; old JSON rows still deserialize).

## Verification

- [x] `cargo test -p messenger-core` — 96 pass (new: file-payload round-trip, `blob_hash` vector, new request/response variants)
- [x] `cargo test -p messenger-server` — 40 pass (new: store/dedup/refcount, size limits, member/channel checks, file DMs, blob+message persistence across reload, dispatch broadcast + download)
- [x] `cargo test -p encodeur_rsa_rust` — 72 pass (client still green with the rendering change)
- [x] `cargo clippy -p messenger-core -p messenger-server -p encodeur_rsa_rust --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean

## Docs And Release Notes

- [x] Platform spec §8 (Phase 2) + roadmap updated to mark slice 1 done and list what remains
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No change to the v3 handshake or `to_plain_bytes`/`from_plain_bytes` wire symmetry; the new messages ride the existing Party framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6VnUASevg4rszRpyNTFUz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline file sharing in Party channels and DMs, with attachments shown in the message list.
  * Added file download support from shared file history.
  * Files are stored with content-based deduplication and persisted for later retrieval.

* **Bug Fixes**
  * Improved handling of file messages across client and server flows.
  * Added safeguards for empty or oversized file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->