### PR TITLE
release: v1.11.1 — fix broken release pipeline + dependency rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-06-29
+
+### Fixed
+
+- **Release pipeline produces binaries again.** The `v1.11.0` tag shipped with a
+  stale `Cargo.lock`, so every platform job in the Release workflow failed at
+  `cargo build --locked` and no installers/archives were attached to the release.
+  The lockfile is now kept in sync with the workspace version, restoring the
+  Windows installer, macOS DMGs, and Linux tarball as release assets.
+
+### Dependencies
+
+- Rolled up the outstanding Dependabot updates: the grouped `rust-minor` updates,
+  `rfd` 0.14 → 0.17, `rusqlite` 0.32 → 0.40, `mdns-sd` 0.11 → 0.20, `emojis`
+  0.6 → 0.9, and the desktop frontend's `react`/`react-dom` 18 → 19, `vite`
+  6 → 8, `@vitejs/plugin-react` 4 → 6, and `lucide-react`.
+
 ## [1.11.0] - 2026-06-29
 
 ### Added
@@ -506,6 +523,7 @@ This release transformed the application from a functional prototype into a poli
 - Message history persistence.
 
 [Unreleased]: #
+[1.11.1]: #
 [1.11.0]: #
 [1.10.1]: #
 [1.10.0]: #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "encodeur_rsa_rust"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "messenger-core"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "messenger-server"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "messenger-core",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "p2pem-desktop"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["core", "client", "server", "desktop/src-tauri"]
 default-members = ["client"]
 
 [workspace.package]
-version = "1.11.0"
+version = "1.11.1"
 edition = "2021"
 rust-version = "1.86"
 authors = ["fibo3090 <fibo3090@example.com>"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Encrypted P2P Messenger
 
-[![Version](https://img.shields.io/badge/version-1.11.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.11.1-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-orange)](LICENSE.md)
 [![Security](https://img.shields.io/badge/security-medium-yellow)](SECURITY.md)
 [![Rust](https://img.shields.io/badge/rust-1.86+-orange)](https://www.rust-lang.org/)


### PR DESCRIPTION
## Summary

Patch release that **fixes the broken `v1.11.0` release** and rolls up the merged Dependabot updates.

### Why
The `v1.11.0` tag shipped with a **stale `Cargo.lock`**. Every platform job in the Release workflow died at `cargo build --locked`, so **no installers/archives were attached** to the v1.11.0 release (it has zero assets; v1.9.0 has all four). This re-releases as `v1.11.1` with a synchronized lockfile so the Windows installer, macOS DMGs, and Linux tarball publish again.

### Changes
- `Cargo.toml`: workspace version `1.11.0` → `1.11.1`
- `Cargo.lock`: sync the four workspace crate entries to `1.11.1` (only those 4 lines change)
- `README.md`: version badge → `1.11.1`
- `CHANGELOG.md`: new `[1.11.1]` section (release fix + dependency rollup)

### Dependency rollup (already merged to `main` via Dependabot #41–#50)
rust-minor group (15 updates), `rfd` 0.14→0.17, `rusqlite` 0.32→0.40, `mdns-sd` 0.11→0.20, `emojis` 0.6→0.9, and the desktop frontend's `react`/`react-dom` 18→19, `vite` 6→8, `@vitejs/plugin-react` 4→6, `lucide-react`.

### Verification
- `cargo check --locked -p encodeur_rsa_rust -p messenger-server` passes locally against the new dependency tree (exit 0).
- CI on this PR validates the full `cargo build --workspace --locked`, fmt, clippy, and tests on Linux/Windows/macOS.

After merge, tagging `v1.11.1` triggers the Release workflow to build and upload the binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a release issue that prevented expected release assets from being produced.
* **Chores**
  * Updated the app version to 1.11.1.
  * Rolled up dependency updates for core and desktop frontend packages.
* **Documentation**
  * Added the 1.11.1 changelog entry and refreshed the version badge in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->