### PR TITLE
fix(server): enforce access control on party file downloads

### DIFF
--- a/server/src/dispatch.rs
+++ b/server/src/dispatch.rs
@@ -180,8 +180,10 @@ pub fn handle_request(state: &mut PartyState, conn: &mut ConnState, req: PartyRe
                     },
                     Err(e) => Dispatch::reply(PartyResponse::Error(e)),
                 },
-                PartyRequest::DownloadFile { hash } => match state.blob_bytes(&hash) {
+                PartyRequest::DownloadFile { hash } => match state.blob_bytes_for(member, &hash) {
                     Some(data) => Dispatch::reply(PartyResponse::FileData { hash, data }),
+                    // Same reply for unknown and access-denied, so the endpoint
+                    // never reveals a file the member isn't allowed to see.
                     None => Dispatch::reply(PartyResponse::Error("unknown file".to_string())),
                 },
             }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -599,6 +599,43 @@ impl PartyState {
         self.blobs.get(hash).map(|r| r.data.clone())
     }
 
+    /// Whether `member` may download the blob `hash`. A file is accessible only if
+    /// it is referenced by a message in a public channel (every member can read
+    /// those) or in a DM thread the member is a party to. Without this, any joined
+    /// member who learned a content hash could fetch a file shared privately in a
+    /// DM between two *other* members — content-addressed storage is shared, but
+    /// the download endpoint must still enforce who can see what.
+    fn member_can_access_blob(&self, member: Uuid, hash: &str) -> bool {
+        let references =
+            |env: &Envelope| matches!(&env.payload, MessagePayload::File(f) if f.hash == hash);
+        // Public channels are readable by every member.
+        if self
+            .channels
+            .iter()
+            .any(|c| c.messages.iter().any(references))
+        {
+            return true;
+        }
+        // Otherwise only DM threads this member participates in (the thread id is
+        // derived from the two members' ids).
+        self.members.keys().any(|other| {
+            let tid = messenger_core::party::dm_thread_id(member, *other);
+            self.dm_threads
+                .get(&tid)
+                .is_some_and(|t| t.messages.iter().any(references))
+        })
+    }
+
+    /// The bytes of a stored blob, but only when `member` is permitted to see it.
+    /// Returns `None` both when the blob is unknown and when access is denied, so
+    /// the endpoint never reveals the existence of a file the member can't access.
+    pub fn blob_bytes_for(&self, member: Uuid, hash: &str) -> Option<Vec<u8>> {
+        if !self.member_can_access_blob(member, hash) {
+            return None;
+        }
+        self.blob_bytes(hash)
+    }
+
     // --- Durable mirroring (best-effort: failures are logged, not propagated, so a
     // transient disk error never drops a live request) --------------------------
 
@@ -1455,6 +1492,66 @@ mod tests {
                 vec![1u8; 6],
             )
             .expect("re-upload of stored content adds no bytes and stays allowed");
+    }
+
+    #[test]
+    fn download_is_denied_for_a_dm_file_a_member_cannot_see() {
+        let mut state = PartyState::new("Open", None);
+        let alice = state.join("alice", None, None).unwrap();
+        let bob = state.join("bob", None, None).unwrap();
+        let mallory = state.join("mallory", None, None).unwrap();
+
+        // Alice sends Bob a private file over a DM.
+        let env = state
+            .post_file_dm(
+                alice,
+                bob,
+                "secret.pdf".into(),
+                "application/pdf".into(),
+                b"top secret".to_vec(),
+            )
+            .unwrap();
+        let hash = file_payload(&env).hash.clone();
+
+        // Both participants can download it...
+        assert_eq!(
+            state.blob_bytes_for(alice, &hash),
+            Some(b"top secret".to_vec())
+        );
+        assert_eq!(
+            state.blob_bytes_for(bob, &hash),
+            Some(b"top secret".to_vec())
+        );
+        // ...but a third member cannot, even if they somehow learn the hash.
+        assert_eq!(
+            state.blob_bytes_for(mallory, &hash),
+            None,
+            "a non-participant must not be able to download a private DM file"
+        );
+    }
+
+    #[test]
+    fn download_of_a_channel_file_is_allowed_for_any_member() {
+        let mut state = PartyState::new("Open", None);
+        let alice = state.join("alice", None, None).unwrap();
+        let bob = state.join("bob", None, None).unwrap();
+        let chan = state.default_channel();
+
+        let env = state
+            .post_file(
+                alice,
+                chan,
+                "pic.png".into(),
+                "image/png".into(),
+                b"pixels".to_vec(),
+            )
+            .unwrap();
+        let hash = file_payload(&env).hash.clone();
+
+        // A public-channel file is downloadable by any member, not just the poster.
+        assert_eq!(state.blob_bytes_for(bob, &hash), Some(b"pixels".to_vec()));
+        // An unknown hash is denied.
+        assert_eq!(state.blob_bytes_for(bob, "deadbeef"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Flaw found auditing the unreviewed feature PRs

I reviewed the two substantive PRs that were merged with **no review comments** — **#37** (party channels + DMs) and **#40** (content-addressed file sharing) — going through the server's dispatch (authorization), connection loop, hub fan-out, transport framing, and state layer.

Most of it holds up well: the transport (`recv_packet`) is DoS-hardened (rejects oversized length prefixes, chunked reads), dispatch enforces "join before acting", `FetchDmHistory` keys the thread by the **caller's own** member id (so no one can read another pair's DMs), and the hub fan-out is correct.

**One real access-control flaw:** `DownloadFile { hash }` called `state.blob_bytes(&hash)`, which returns any stored blob by content hash with **no authorization check**. Because blob storage is content-addressed and shared globally (for dedup), a joined member who learned a file's SHA-256 hash could download a file that was only ever shared in a **DM between two other members**. The only thing standing in the way was hash unguessability — not actual access control.

## Fix

`PartyState::blob_bytes_for(member, hash)` returns the bytes only when the blob is referenced by a message in a **public channel** (all members can read those) or in a **DM thread the member participates in** (thread id derived from the member pair). Unknown-hash and access-denied both return `None`, so the endpoint doesn't reveal whether a file exists. `DownloadFile` now uses it.

## Tests

- `download_is_denied_for_a_dm_file_a_member_cannot_see` — Alice DMs Bob a file; both participants can download it, a third member (Mallory) cannot even with the hash.
- `download_of_a_channel_file_is_allowed_for_any_member` — a public-channel file stays downloadable by any member; an unknown hash is denied.

Full suite: `cargo nextest run --workspace` → **288/288 pass**; `cargo clippy -p messenger-server` clean.

## Also noted (not fixed here)
- Member usernames, channel names, and message text have no explicit length caps (bounded only by the 8 MiB packet limit) — a minor resource-growth concern for an append-only administered server. Happy to add caps if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTyRxk3ruxo6kpkwTv5c4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File downloads now respect member-level access, so shared content is only available to authorized members.
  * Missing files and access-denied downloads now return the same generic error, preventing information leaks.
  * Downloads from public channels and direct messages continue to work for eligible members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->