### PR TITLE
fix: distinct desktop app identity + real host-side TOFU verification

### DIFF
--- a/client/src/app/chat_manager.rs
+++ b/client/src/app/chat_manager.rs
@@ -1572,6 +1572,16 @@ impl ChatManager {
             .map(|(&cid, _)| cid)
             .unwrap_or(session_id);
 
+        // Have we already confirmed this fingerprint elsewhere (another chat with
+        // this peer, or a saved contact)? Then it's a returning peer under TOFU and
+        // we accept without another prompt. Computed before the mutable borrow below.
+        let known_trusted = self.chats.iter().any(|(id, c)| {
+            *id != actual_chat_id && c.peer_fingerprint.as_deref() == Some(fingerprint)
+        }) || self
+            .contacts
+            .values()
+            .any(|c| c.fingerprint.as_deref() == Some(fingerprint));
+
         let chat = match self.chats.get_mut(&actual_chat_id) {
             Some(c) => c,
             None => {
@@ -1587,8 +1597,9 @@ impl ChatManager {
                     "Trust on First Use for chat {}. Requesting user confirmation.",
                     actual_chat_id
                 );
-                // If user opted into auto-trust (not recommended), allow it.
-                if self.config.auto_trust_on_first_use {
+                // Auto-trust only if the user opted in, or this fingerprint is one
+                // we've already verified (a returning peer) — otherwise prompt.
+                if self.config.auto_trust_on_first_use || known_trusted {
                     tracing::info!(
                         "auto_trust_on_first_use enabled: auto-storing fingerprint for chat {}",
                         actual_chat_id
@@ -1710,7 +1721,10 @@ impl ChatManager {
                         title,
                         kind: ChatKind::Dm,
                         transport: inherited_transport,
-                        peer_fingerprint: Some(fingerprint.clone()),
+                        // Leave unset so TOFU actually runs for this incoming peer:
+                        // pre-filling the peer's own fingerprint made the check below
+                        // trivially "match" and silently auto-trust every caller.
+                        peer_fingerprint: None,
                         participants: Vec::new(),
                         messages: Vec::new(),
                         created_at: chrono::Utc::now(),
@@ -2396,6 +2410,60 @@ mod tests {
         assert!(
             contact.address.is_none(),
             "placeholder address must be ignored"
+        );
+    }
+
+    #[test]
+    fn host_prompts_for_an_unknown_incoming_fingerprint() {
+        // Simulate an incoming connection: a fresh chat (no stored fingerprint)
+        // mapped from the peer's chat id to the session id, plus a confirm channel.
+        let mut mgr = ChatManager::new(Config::default());
+        let session_id = Uuid::new_v4();
+        let incoming = Uuid::new_v4();
+        mgr.create_local_chat_for_test(incoming, "Peer".into());
+        mgr.chat_id_mapping.insert(incoming, session_id);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        mgr.add_fingerprint_confirm_sender_for_test(session_id, tx);
+
+        mgr.handle_tofu_verification(session_id, "UNKNOWN-FP", "Peer");
+
+        // The host must PROMPT for verification, not silently auto-trust.
+        assert!(
+            mgr.fingerprint_verification_request.is_some(),
+            "host must prompt to verify an unknown incoming peer"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "host must not auto-confirm an unknown incoming peer"
+        );
+    }
+
+    #[test]
+    fn host_auto_accepts_a_returning_known_fingerprint() {
+        // A prior chat already has this fingerprint verified (a returning peer).
+        let mut mgr = ChatManager::new(Config::default());
+        let prior = Uuid::new_v4();
+        mgr.create_local_chat_for_test(prior, "Known".into());
+        mgr.get_chat_mut(prior).unwrap().peer_fingerprint = Some("KNOWN-FP".into());
+
+        let session_id = Uuid::new_v4();
+        let incoming = Uuid::new_v4();
+        mgr.create_local_chat_for_test(incoming, "Peer".into());
+        mgr.chat_id_mapping.insert(incoming, session_id);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        mgr.add_fingerprint_confirm_sender_for_test(session_id, tx);
+
+        mgr.handle_tofu_verification(session_id, "KNOWN-FP", "Peer");
+
+        // Returning peer: auto-confirmed without re-prompting.
+        assert!(
+            mgr.fingerprint_verification_request.is_none(),
+            "a known fingerprint must not trigger another prompt"
+        );
+        assert_eq!(
+            rx.try_recv().ok(),
+            Some(true),
+            "a known fingerprint must be auto-confirmed"
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -904,11 +904,27 @@ pub fn run() {
 
 /// Build the identity + manager, mirroring `gui::App::new`'s data-dir setup.
 fn init_bridge() -> Bridge {
-    let proj = directories::ProjectDirs::from("com", "chat-p2p", "EncryptedMessenger");
-    let (history_path, identity, is_new) = if let Some(dirs) = proj {
-        let data = dirs.data_dir();
-        std::fs::create_dir_all(data).ok();
-        let (id, isnew) = Identity::get_or_create(data, "User").unwrap_or_else(|e| {
+    // The data dir holds `identity.json` (this peer's key/fingerprint) and the
+    // encrypted history. It uses the desktop app's OWN identifier ("P2PEM"), NOT
+    // the egui app's ("EncryptedMessenger"): sharing one dir made both apps load
+    // the same identity, so they were the same P2P peer and could not connect to
+    // each other (a connection between them was a self-connection). With distinct
+    // dirs the two apps are distinct peers and connect normally.
+    //
+    // `P2PEM_DATA_DIR` overrides it, so extra instances can each run with their
+    // own identity/history — handy for testing several peers on one machine:
+    //   P2PEM_DATA_DIR=%LOCALAPPDATA%\p2pem-test cargo tauri dev
+    let data_dir: Option<PathBuf> = std::env::var_os("P2PEM_DATA_DIR")
+        .map(PathBuf::from)
+        .or_else(|| {
+            directories::ProjectDirs::from("com", "chat-p2p", "P2PEM")
+                .map(|dirs| dirs.data_dir().to_path_buf())
+        });
+
+    let (history_path, identity, is_new) = if let Some(data) = data_dir {
+        std::fs::create_dir_all(&data).ok();
+        tracing::info!(data_dir = %data.display(), "using data directory");
+        let (id, isnew) = Identity::get_or_create(&data, "User").unwrap_or_else(|e| {
             tracing::error!("identity load/create failed: {e}; falling back to plaintext");
             (
                 Identity::new_with_plaintext("User".to_string()).expect("identity"),


### PR DESCRIPTION
Fixes the P2P cross-compatibility bug ("hosting on egui + connecting via Tauri is broken, reverse works") and a related host-side TOFU weakness found during the investigation.

## 1. Desktop app shared egui''s identity (root cause of the connectivity bug)
`init_bridge` resolved its data dir from **egui''s** `ProjectDirs("com","chat-p2p","EncryptedMessenger")` instead of the desktop app''s own identifier. So egui and Tauri loaded the **same `identity.json`** — same RSA key, same fingerprint, same peer — and clobbered the same `history.json.enc`. Connecting them on one machine was a **self-connection**; the host-direction asymmetry was the two processes racing on the shared history file. (Verified the core handshake itself tolerates a same-identity connection, so this was purely app-level.)

Fix: the desktop app uses its own data dir (`"P2PEM"`), plus a `P2PEM_DATA_DIR` env override to run extra test peers on one machine. Two different machines already had distinct identities and were unaffected.

## 2. Host auto-trusted every incoming peer (TOFU bypass)
The incoming chat was created with the peer''s fingerprint **pre-filled**, so `handle_tofu_verification` trivially "matched" and auto-confirmed — the host never prompted to verify who connected. Now the incoming chat starts with no fingerprint (first contact prompts), and a fingerprint already verified in another chat/contact is recognized so returning peers aren''t re-prompted.

## Verification
- `cargo clippy` (client + desktop) clean; `cargo fmt` applied
- New tests: `host_prompts_for_an_unknown_incoming_fingerprint`, `host_auto_accepts_a_returning_known_fingerprint`
- Client suite: 141/141 pass

Note: the desktop app will create a fresh identity in its new dir on next launch (a fresh start, as confirmed acceptable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTyRxk3ruxo6kpkwTv5c4