### PR TITLE
feat(server,tui): community hosting CLI, TUI file sharing, filename sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Community file sharing from the TUI.** `:party-send-file <path>` shares a
+  file into the current community's channel and `:party-download <name|hash>`
+  saves a shared file into the download folder — files no longer work only in
+  the desktop app. Downloads never overwrite existing files (`name (2).ext`).
+- **A real server CLI.** `messenger-server` now takes `--name`, `--port`,
+  `--password`, and `--data-dir` flags (with `--help`/`--version`), so hosting
+  a community no longer requires environment variables, the community's display
+  name is finally configurable (it was hardcoded to "Encrypted Messenger
+  Party"), and the port is no longer fixed at 12345. The old `PARTY_*`
+  environment variables still work as fallbacks. Hosting is now documented in
+  the user guide ("Host a community").
 - **Community unread badges in the desktop app.** Channels, DM threads, and the
   community switcher now show unread counts, and the Communities rail icon
   badges the total — including messages that arrive while you're on another
@@ -67,6 +78,11 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+- **Community file names are sanitized server-side.** A member-chosen file name
+  like `..\..\Startup\evil.exe` is reduced to a safe filename at upload (the
+  single choke point for channel and DM files), so no client can be handed a
+  name that escapes its download directory. P2P transfers already had this at
+  protocol decode; TUI downloads also re-sanitize on save (defense in depth).
 - **Party input length caps.** The server now bounds member usernames (≤ 32
   characters), channel names (≤ 64 characters), and channel/DM message text (≤ 64
   KiB, matching the P2P transport cap) instead of accepting any string up to the 8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4226,6 +4226,7 @@ name = "messenger-server"
 version = "1.11.1"
 dependencies = [
  "anyhow",
+ "clap",
  "messenger-core",
  "rsa",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 egui_tracing = { version = "0.2.6", features = ["egui-default"] }
 
 # CLI
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 
 # GUI
 eframe = "0.29.0"

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -73,7 +73,7 @@ cargo check -p p2pem-desktop               # the desktop crate has no tests
 cd desktop && npm run build                # verify the React frontend builds
 ```
 
-The workspace test suite is currently **298 tests**. The `p2pem-desktop` crate is
+The workspace test suite is currently **301 tests**. The `p2pem-desktop` crate is
 not exercised by the test suite and cannot be driven headlessly here, so it is
 verified by `cargo check` + `npm run build` only.
 

--- a/client/src/tui/app.rs
+++ b/client/src/tui/app.rs
@@ -27,6 +27,13 @@ use uuid::Uuid;
 
 pub use crate::tui::command::TuiCommand;
 
+/// A pending Party file download: the byte receiver plus the file's display
+/// name (used for the saved filename and progress toasts).
+type PendingPartyDownload = (
+    tokio::sync::oneshot::Receiver<Result<Vec<u8>, String>>,
+    String,
+);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TuiFocus {
     ChatList,
@@ -75,6 +82,9 @@ pub struct TuiApp {
     identity_path: PathBuf,
     history_path: PathBuf,
     pending_command: Option<TuiCommand>,
+    /// In-flight Party file downloads. `tick` polls them and writes finished
+    /// downloads into the download directory.
+    pending_party_downloads: Vec<PendingPartyDownload>,
     /// Per-chat count of messages already seen (for unread detection).
     seen_counts: HashMap<Uuid, usize>,
     unread: HashSet<Uuid>,
@@ -145,6 +155,7 @@ impl TuiApp {
             identity_path,
             history_path,
             pending_command: None,
+            pending_party_downloads: Vec::new(),
             seen_counts: HashMap::new(),
             unread: HashSet::new(),
             last_save: None,
@@ -158,6 +169,57 @@ impl TuiApp {
         app.sync_chat_ids();
         app.refresh_status_line();
         Ok(app)
+    }
+
+    /// Drain finished Party file downloads: write the bytes into the download
+    /// directory under a sanitized, non-clobbering name and toast the outcome.
+    fn poll_party_downloads(&mut self) {
+        if self.pending_party_downloads.is_empty() {
+            return;
+        }
+        let download_dir = self.chat_manager.config.download_dir.clone();
+        let mut i = 0;
+        while i < self.pending_party_downloads.len() {
+            use tokio::sync::oneshot::error::TryRecvError;
+            match self.pending_party_downloads[i].0.try_recv() {
+                Err(TryRecvError::Empty) => i += 1,
+                Ok(result) => {
+                    let (_, name) = self.pending_party_downloads.remove(i);
+                    match result {
+                        Ok(data) => {
+                            // The name was chosen by another member: sanitize it
+                            // (defense in depth — the server sanitizes too) and
+                            // never overwrite an existing file.
+                            let safe = crate::util::sanitize_filename(&name);
+                            let path = unique_download_path(&download_dir, &safe);
+                            let write = std::fs::create_dir_all(&download_dir)
+                                .and_then(|_| std::fs::write(&path, &data));
+                            match write {
+                                Ok(()) => self.toast(
+                                    ToastLevel::Success,
+                                    format!("Saved '{}'", path.display()),
+                                ),
+                                Err(e) => self.toast(
+                                    ToastLevel::Error,
+                                    format!("Saving '{safe}' failed: {e}"),
+                                ),
+                            }
+                        }
+                        Err(reason) => self.toast(
+                            ToastLevel::Error,
+                            format!("Download of '{name}' failed: {reason}"),
+                        ),
+                    }
+                }
+                Err(TryRecvError::Closed) => {
+                    let (_, name) = self.pending_party_downloads.remove(i);
+                    self.toast(
+                        ToastLevel::Error,
+                        format!("Download of '{name}' failed: connection closed"),
+                    );
+                }
+            }
+        }
     }
 
     /// At startup, greet the user with a password overlay when appropriate:
@@ -239,6 +301,7 @@ impl TuiApp {
     pub fn tick(&mut self) {
         self.chat_manager.poll_session_events();
         self.party_manager.poll_events();
+        self.poll_party_downloads();
         self.chat_manager.cleanup_expired_toasts();
 
         // Surface a pending fingerprint verification as an overlay.
@@ -1121,6 +1184,85 @@ impl TuiApp {
                     Err(e) => self.toast(ToastLevel::Error, format!("Create channel failed: {e}")),
                 }
             }
+            TuiCommand::PartySendFile(path) => {
+                let Some(server_id) = self.current_party else {
+                    self.toast(
+                        ToastLevel::Error,
+                        "No Party server joined. Use :party-connect".to_string(),
+                    );
+                    return;
+                };
+                let Some(channel) = self
+                    .party_manager
+                    .server(server_id)
+                    .and_then(|s| s.channels.first().map(|c| c.id))
+                else {
+                    self.toast(ToastLevel::Error, "Party has no channels yet".to_string());
+                    return;
+                };
+                let p = std::path::Path::new(&path);
+                let name = p
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("file")
+                    .to_string();
+                let mime = crate::util::guess_mime(p).to_string();
+                match std::fs::read(p) {
+                    Ok(data) => match self.party_manager.send_file(
+                        server_id,
+                        channel,
+                        name.clone(),
+                        mime,
+                        data,
+                    ) {
+                        Ok(()) => self.toast(ToastLevel::Info, format!("Sharing '{name}'…")),
+                        Err(e) => self.toast(ToastLevel::Error, format!("Share failed: {e}")),
+                    },
+                    Err(e) => self.toast(ToastLevel::Error, format!("Could not read {path}: {e}")),
+                }
+            }
+            TuiCommand::PartyDownload(query) => {
+                let Some(server_id) = self.current_party else {
+                    self.toast(
+                        ToastLevel::Error,
+                        "No Party server joined. Use :party-connect".to_string(),
+                    );
+                    return;
+                };
+                // Match a shared file by name substring or content-hash prefix
+                // across everything this client has seen on the server.
+                let q = query.to_ascii_lowercase();
+                let meta = self.party_manager.server(server_id).and_then(|s| {
+                    s.messages
+                        .values()
+                        .flatten()
+                        .find_map(|env| match &env.payload {
+                            messenger_core::party::MessagePayload::File(f)
+                                if f.name.to_ascii_lowercase().contains(&q)
+                                    || f.hash.starts_with(&q) =>
+                            {
+                                Some(f.clone())
+                            }
+                            _ => None,
+                        })
+                });
+                match meta {
+                    Some(f) => match self
+                        .party_manager
+                        .request_download(server_id, f.hash.clone())
+                    {
+                        Ok(rx) => {
+                            self.pending_party_downloads.push((rx, f.name.clone()));
+                            self.toast(ToastLevel::Info, format!("Downloading '{}'…", f.name));
+                        }
+                        Err(e) => self.toast(ToastLevel::Error, format!("Download failed: {e}")),
+                    },
+                    None => self.toast(
+                        ToastLevel::Error,
+                        format!("No shared file matches '{query}'"),
+                    ),
+                }
+            }
             TuiCommand::PartyStatus => {
                 let ids = self.party_manager.server_ids();
                 if ids.is_empty() {
@@ -1525,6 +1667,32 @@ impl TuiApp {
     }
 }
 
+/// A path under `dir` for `name` that does not collide with an existing file:
+/// `name`, then `name (2)`, `name (3)`, … so a download never silently
+/// overwrites something the user already has.
+fn unique_download_path(dir: &std::path::Path, name: &str) -> PathBuf {
+    let first = dir.join(name);
+    if !first.exists() {
+        return first;
+    }
+    let p = std::path::Path::new(name);
+    let stem = p
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("received_file");
+    let ext = p.extension().and_then(|e| e.to_str());
+    for n in 2.. {
+        let candidate = match ext {
+            Some(ext) => dir.join(format!("{stem} ({n}).{ext}")),
+            None => dir.join(format!("{stem} ({n})")),
+        };
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    unreachable!("the counter loop always returns")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1538,6 +1706,28 @@ mod tests {
 
     fn key(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn unique_download_path_never_clobbers() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = unique_download_path(dir.path(), "report.pdf");
+        assert_eq!(first, dir.path().join("report.pdf"));
+
+        std::fs::write(&first, b"one").unwrap();
+        let second = unique_download_path(dir.path(), "report.pdf");
+        assert_eq!(second, dir.path().join("report (2).pdf"));
+
+        std::fs::write(&second, b"two").unwrap();
+        let third = unique_download_path(dir.path(), "report.pdf");
+        assert_eq!(third, dir.path().join("report (3).pdf"));
+
+        // Extensionless names get the suffix too.
+        std::fs::write(dir.path().join("notes"), b"x").unwrap();
+        assert_eq!(
+            unique_download_path(dir.path(), "notes"),
+            dir.path().join("notes (2)")
+        );
     }
 
     #[test]

--- a/client/src/tui/command.rs
+++ b/client/src/tui/command.rs
@@ -79,6 +79,11 @@ pub enum TuiCommand {
     },
     /// Create a channel on the current Party server.
     PartyCreateChannel(String),
+    /// Share a local file into the current Party server's channel.
+    PartySendFile(String),
+    /// Download a shared file (matched by name or content-hash prefix) from the
+    /// current Party server into the download directory.
+    PartyDownload(String),
     PartyStatus,
 
     // --- settings ---
@@ -172,6 +177,16 @@ pub const COMMANDS: &[(&str, &str, &str)] = &[
         "party-create-channel",
         ":party-create-channel <name>",
         "Create a channel on the current Party server",
+    ),
+    (
+        "party-send-file",
+        ":party-send-file <path>",
+        "Share a file in the current Party channel",
+    ),
+    (
+        "party-download",
+        ":party-download <name|hash>",
+        "Save a shared Party file to your download folder",
     ),
     ("party-status", ":party-status", "Show joined Party servers"),
     ("rename", ":rename <title>", "Rename the selected chat"),
@@ -421,6 +436,18 @@ pub fn parse_command(raw: &str) -> std::result::Result<TuiCommand, String> {
             }
             Ok(TuiCommand::PartyCreateChannel(rest))
         }
+        "party-send-file" => {
+            if rest.is_empty() {
+                return Err("Usage: :party-send-file <path>".to_string());
+            }
+            Ok(TuiCommand::PartySendFile(rest))
+        }
+        "party-download" => {
+            if rest.is_empty() {
+                return Err("Usage: :party-download <name|hash>".to_string());
+            }
+            Ok(TuiCommand::PartyDownload(rest))
+        }
         "party-status" => Ok(TuiCommand::PartyStatus),
 
         "rename" => {
@@ -516,6 +543,22 @@ mod tests {
                 token: "tok".into()
             }
         );
+    }
+
+    #[test]
+    fn parses_party_file_commands() {
+        assert_eq!(
+            parse_command(":party-send-file C:\\pics\\cat photo.png").unwrap(),
+            TuiCommand::PartySendFile("C:\\pics\\cat photo.png".into()),
+            "the whole rest (spaces included) is the path"
+        );
+        assert!(parse_command(":party-send-file").is_err());
+
+        assert_eq!(
+            parse_command(":party-download cat photo.png").unwrap(),
+            TuiCommand::PartyDownload("cat photo.png".into())
+        );
+        assert!(parse_command(":party-download").is_err());
     }
 
     #[test]

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -134,6 +134,31 @@ pub fn format_fingerprint_short(fp: &str) -> String {
     }
 }
 
+/// A minimal extension → MIME guess for common file types; defaults to
+/// `application/octet-stream`. Display metadata only — never used for security
+/// decisions.
+pub fn guess_mime(path: &std::path::Path) -> &'static str {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        "pdf" => "application/pdf",
+        "txt" | "log" | "md" => "text/plain",
+        "json" => "application/json",
+        "zip" => "application/zip",
+        "mp4" => "video/mp4",
+        "mp3" => "audio/mpeg",
+        _ => "application/octet-stream",
+    }
+}
+
 /// Best-effort discovery of the primary local IPv4 address.
 /// Uses a UDP "connect" to a public resolver to learn the outbound interface.
 pub fn primary_local_ipv4() -> Option<String> {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1135,34 +1135,9 @@ async fn pick_upload() -> Result<Option<(String, String, Vec<u8>)>, String> {
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| "file".to_string());
-    let mime = guess_mime(&path);
+    let mime = messenger_core::util::guess_mime(&path).to_string();
     let data = std::fs::read(&path).map_err(|e| e.to_string())?;
     Ok(Some((name, mime, data)))
-}
-
-/// A minimal extension → MIME guess for common file types; defaults to
-/// `application/octet-stream`. The server keeps this only as display metadata.
-fn guess_mime(path: &std::path::Path) -> String {
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase();
-    match ext.as_str() {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        "svg" => "image/svg+xml",
-        "pdf" => "application/pdf",
-        "txt" | "log" | "md" => "text/plain",
-        "json" => "application/json",
-        "zip" => "application/zip",
-        "mp4" => "video/mp4",
-        "mp3" => "audio/mpeg",
-        _ => "application/octet-stream",
-    }
-    .to_string()
 }
 
 /// Pick a file and post it to a community channel. The picker runs on a blocking

--- a/docs/05_platform_spec.md
+++ b/docs/05_platform_spec.md
@@ -571,7 +571,7 @@ onion routing / anonymity layer, post-quantum migration, hardware-backed identit
 
 ## 13. Verification & Test Coverage
 
-The workspace passes **298 automated tests** (`cargo nextest run --workspace`)
+The workspace passes **301 automated tests** (`cargo nextest run --workspace`)
 spanning unit, integration, and end-to-end suites (the `p2pem-desktop` crate has
 no automated tests — it is verified with `cargo check -p p2pem-desktop` and
 `npm run build`):
@@ -621,7 +621,7 @@ The one area not deeply automated is GUI pixel rendering; the logic behind it
 ## 14. Status
 
 Phase 0 (workspace) and the Phase 1 Party server core are complete; the suite is
-green at 298 tests. The **Tauri + React desktop app** (§10) has shipped its P2P,
+green at 301 tests. The **Tauri + React desktop app** (§10) has shipped its P2P,
 Party, Relay, Contacts, and Settings surfaces (phases A–D) as the `desktop/` crate,
 closing most of the Phase 1 UI-polish items; retiring egui and rebuilding packaging
 (phases E–F) remain. The Independent P2P hardening (connection passwords +

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -165,6 +165,48 @@ Relay notes:
 - it forwards already encrypted session traffic
 - it improves reachability, not anonymity
 
+### Host a community (Party server)
+
+Communities are self-hosted, multi-user rooms with channels, direct messages,
+file sharing, and durable history — members who were offline catch up when they
+reconnect. One person runs the server; friends join with just an address, an
+optional password, and a username.
+
+Start a server:
+
+```bash
+cargo run --release -p messenger-server -- --name "Game Night" --port 12345
+```
+
+Options (also settable via `PARTY_NAME`, `PARTY_PORT`, `PARTY_PASSWORD`,
+`PARTY_DATA_DIR` environment variables):
+
+- `--name <NAME>` — the community name everyone sees (default: "Encrypted Messenger Party")
+- `--port <PORT>` — TCP port to listen on (default: 12345)
+- `--password <PASSWORD>` — require a password to join (omit for an open server)
+- `--data-dir <DIR>` — where the database, file store, and server identity live (default: `party-data`)
+
+On startup the server prints its **fingerprint**. Share your address
+(`your-ip:port`) and that fingerprint with the people you invite; their app pins
+the fingerprint on first join and warns them if it ever changes.
+
+Joining from the app:
+
+- **Desktop app**: Communities tab → enter the address, a username, and the
+  password if one is set. Rejoining later is one click (communities are
+  remembered).
+- **TUI**: `:party-connect <host[:port]> <username> [password]`
+- **GUI (egui)**: the Party window → join form.
+
+Operator notes:
+
+- state persists under the data dir (`party.db` + `blobs/`); back it up to keep
+  history
+- the server can read message contents (this is the "Administered" trust tier —
+  it is what enables offline delivery and history); tell your members
+- members are remembered by identity fingerprint, so someone who reconnects
+  keeps their username and history
+
 ### Verify fingerprints
 
 The app uses TOFU. First contact is only meaningful if you verify the fingerprint out of band.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "messenger-server"
-description = "Party server for the Encrypted Messenger (placeholder; implemented in Phase 1)."
+description = "Self-hosted Party/Community server for the Encrypted Messenger: channels, DMs, file sharing, and offline history over the v3 encrypted transport."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -16,6 +16,7 @@ messenger-core = { workspace = true }
 
 tokio = { workspace = true }
 anyhow = { workspace = true }
+clap = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,13 +1,11 @@
-//! Party server for the Encrypted Messenger.
+//! Party/Community server for the Encrypted Messenger.
 //!
-//! Phase 1: the server binds a TCP listener and serves each client over a reused
+//! The server binds a TCP listener and serves each client over a reused
 //! Protocol v3 encrypted tunnel ([`messenger_core::network::host_handshake`]),
 //! driving the shared [`state::PartyState`] via the [`dispatch`] layer. Members
-//! join with a username + the optional server password, post to channels, and the
-//! server stores history so offline members catch up on reconnect.
-//!
-//! Not yet wired (next step): SQLite/blob persistence of state and history. See
-//! `docs/05_platform_spec.md`.
+//! join with a username + the optional server password, post to channels and DMs,
+//! share files, and the server stores history durably (SQLite + blob store) so
+//! offline members catch up on reconnect.
 
 mod connection;
 mod dispatch;
@@ -18,6 +16,7 @@ mod state;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use clap::Parser;
 use messenger_core::core::{fingerprint_pubkey, pem_encode_public};
 use rsa::RsaPublicKey;
 use tokio::net::TcpListener;
@@ -25,6 +24,31 @@ use tokio::sync::Mutex;
 
 use hub::Hub;
 use state::PartyState;
+
+/// Self-hosted Community (Party) server. Friends join with your address, an
+/// optional password, and a username — no port forwarding gymnastics on their
+/// side, no account system. All transport is end-to-end encrypted to the server
+/// (Protocol v3); clients pin this server's fingerprint on first join.
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Display name of this community, shown to everyone who joins.
+    #[arg(long, env = "PARTY_NAME", default_value = "Encrypted Messenger Party")]
+    name: String,
+
+    /// TCP port to listen on.
+    #[arg(long, env = "PARTY_PORT", default_value_t = messenger_core::PORT_DEFAULT)]
+    port: u16,
+
+    /// Require this password to join. Omit for an open server.
+    #[arg(long, env = "PARTY_PASSWORD")]
+    password: Option<String>,
+
+    /// Directory for durable state: member/channel/message database (party.db),
+    /// the file blob store, and the server identity key.
+    #[arg(long, env = "PARTY_DATA_DIR", default_value = "party-data")]
+    data_dir: PathBuf,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -34,35 +58,33 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let data_dir = std::env::var_os("PARTY_DATA_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("party-data"));
-    let server_password = std::env::var("PARTY_PASSWORD").ok();
+    let args = Args::parse();
+    let password_protected = args.password.is_some();
 
     // Durable state: members, channels, and history survive restarts (loaded from
     // and auto-saved to the data dir).
     let state = Arc::new(Mutex::new(PartyState::load(
-        "Encrypted Messenger Party",
-        server_password,
-        &data_dir,
+        &args.name,
+        args.password,
+        &args.data_dir,
     )?));
 
     // Persistent server identity: clients pin this fingerprint via TOFU on first
     // connect, so it must stay stable across restarts.
-    let privkey = Arc::new(identity::load_or_create_server_identity(&data_dir)?);
+    let privkey = Arc::new(identity::load_or_create_server_identity(&args.data_dir)?);
     let fingerprint =
         fingerprint_pubkey(pem_encode_public(&RsaPublicKey::from(&*privkey))?.as_bytes());
     let hub = Arc::new(Hub::new());
 
-    let port = messenger_core::PORT_DEFAULT;
+    let port = args.port;
     let listener = TcpListener::bind(("0.0.0.0", port)).await?;
     tracing::info!(
         server_name = %state.lock().await.name(),
         %fingerprint,
         port,
-        data_dir = %data_dir.display(),
-        password_protected = std::env::var("PARTY_PASSWORD").is_ok(),
-        "Party server listening"
+        data_dir = %args.data_dir.display(),
+        password_protected,
+        "Community server listening — share your address and this fingerprint with people you invite"
     );
 
     loop {

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -29,7 +29,7 @@ use messenger_core::party::{
     blob_hash, ChannelInfo, ChannelKind, Envelope, FileMeta, MemberInfo, MessagePayload, TrustTier,
     MAX_INLINE_FILE_BYTES,
 };
-use messenger_core::util::current_timestamp_millis;
+use messenger_core::util::{current_timestamp_millis, sanitize_filename};
 use rusqlite::{params, Connection};
 use serde::Deserialize;
 use uuid::Uuid;
@@ -533,7 +533,12 @@ impl PartyState {
         }
         Ok(FileMeta {
             hash,
-            name: name.to_string(),
+            // The display name is member-supplied: reduce it to a safe filename
+            // here (the single choke point for channel and DM uploads) so no
+            // client ever receives a name that could escape its download
+            // directory (e.g. `..\..\evil.exe`). P2P transfers get the same
+            // treatment at protocol decode.
+            name: sanitize_filename(name),
             size,
             mime: mime.to_string(),
         })
@@ -1088,6 +1093,35 @@ mod tests {
         let too_long = "d".repeat(MAX_CHANNEL_NAME_CHARS + 1);
         let err = state.create_channel(&too_long).unwrap_err();
         assert!(err.contains("too long"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn uploaded_file_names_are_sanitized_against_path_traversal() {
+        let mut state = PartyState::new("Open", None);
+        let alice = state.join("alice", None, None).unwrap();
+        let chan = state.default_channel();
+
+        // A member-chosen name must never be able to escape a client's download
+        // directory when later joined onto it.
+        let env = state
+            .post_file(
+                alice,
+                chan,
+                "..\\..\\Startup\\evil.exe".to_string(),
+                "application/octet-stream".to_string(),
+                b"payload".to_vec(),
+            )
+            .unwrap();
+        match &env.payload {
+            MessagePayload::File(f) => {
+                assert!(
+                    !f.name.contains("..") && !f.name.contains('\\') && !f.name.contains('/'),
+                    "stored name must be traversal-safe, got {:?}",
+                    f.name
+                );
+            }
+            other => panic!("expected a File payload, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Triggered by a real user question — "how do I create a server?" — which exposed that the hosting journey was undocumented and hostile.

## Hosting a community is now a real product surface
- **`messenger-server` gets a CLI**: `--name`, `--port`, `--password`, `--data-dir` (with `--help`/`--version`). Before: env-vars only, the port was **hardcoded** to 12345, and every community in the world was named "Encrypted Messenger Party". The `PARTY_*` env vars remain as fallbacks — zero breakage for existing operators.
- **"Host a community" documented** in the user guide: options, the fingerprint handshake with invitees, joining from each frontend, and operator notes (backup, Administered-tier trust caveat, identity-based membership).

## TUI parity for community files
- `:party-send-file <path>` shares a file into the current community's channel.
- `:party-download <name|hash>` saves a shared file to the download folder — polls the async download in `tick`, and **never overwrites existing files** (unique `name (2).ext`, tested).

## Security — file-name sanitization at the choke point
- `store_blob()` now sanitizes the member-supplied file name at upload, so no client is ever handed a name like `..\..\Startup\evil.exe` that could escape its download directory when saved. (P2P transfers already had this at protocol decode — verified; the party path did not.) TUI downloads re-sanitize on save as defense in depth. Regression test included.
- `guess_mime` deduped into `messenger_core::util` (shared by the desktop bridge and TUI).

## Verification
- `cargo nextest run --workspace` → **301 passed, 0 skipped** (3 new: server-side sanitization, TUI parser, unique-path)
- `cargo clippy --workspace --all-targets -- -D warnings` → clean; `cargo fmt` applied
- `cargo run -p messenger-server -- --help` → professional help output verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTyRxk3ruxo6kpkwTv5c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added community file sharing from the TUI.
  * Added a real `messenger-server` command with configurable name, port, password, and data directory.
  * Updated file uploads to detect a basic MIME type for better display handling.

* **Security**
  * Added filename sanitization for uploaded community files to help prevent path traversal issues.
  * Downloads now avoid overwriting existing files by automatically choosing a unique name.

* **Documentation**
  * Expanded the user guide, platform spec, developer guide, and changelog to cover community hosting and current test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->