### PR TITLE
chore(release): prepare v1.12.0

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# Gitleaks configuration: extend the default rules with a reviewed allowlist,
+# so a scan is clean by default and any new finding is a real signal.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Reviewed false positives"
+# A sequential hex placeholder ("0123456789abcdef" twice) used as a relay-token
+# test vector in a historical commit (pre-workspace src/ tree). Not a secret.
+regexes = ['''0123456789abcdef0123456789abcdef''']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-07-05
+
 ### Added
 
 - **Community file sharing from the TUI.** `:party-send-file <path>` shares a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,18 +1560,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "encodeur_rsa_rust"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "messenger-core"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "messenger-server"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "p2pem-desktop"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,11 @@ members = ["core", "client", "server", "desktop/src-tauri"]
 default-members = ["client"]
 
 [workspace.package]
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 rust-version = "1.86"
 authors = ["fibo3090 <fibo3090@example.com>"]
+license = "MIT"
 
 [workspace.dependencies]
 # Internal crates

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Encrypted P2P Messenger
 
-[![Version](https://img.shields.io/badge/version-1.11.1-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.0-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-orange)](LICENSE.md)
 [![Security](https://img.shields.io/badge/security-medium-yellow)](SECURITY.md)
 [![Rust](https://img.shields.io/badge/rust-1.86+-orange)](https://www.rust-lang.org/)

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -4,6 +4,7 @@ description = "Encrypted P2P Messenger - a secure peer-to-peer messaging applica
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 authors.workspace = true
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,7 @@ description = "Shared core for the Encrypted Messenger: crypto, wire protocol, i
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 authors.workspace = true
 
 [lib]

--- a/deny.toml
+++ b/deny.toml
@@ -1,30 +1,74 @@
+# cargo-deny configuration (schema v2, cargo-deny >= 0.16).
+# Vulnerabilities, unmaintained crates, unsound advisories, and yanked crates
+# are all errors by default under v2 — no per-category severity keys anymore.
+
 [advisories]
-vulnerability = "deny"
-unmaintained = "deny"
-unsound = "deny"
-notice = "warn"
+version = 2
 # Temporary risk acceptances tracked in GitHub issues and SECURITY.md.
 # Keep this list minimal and review regularly.
 ignore = [
-    "RUSTSEC-2020-0001", # trust-dns-server stack overflow when resolving additional records from MX/SRV null targets
     "RUSTSEC-2023-0071", # rsa Marvin timing issue (no upstream fix yet)
     "RUSTSEC-2024-0436", # paste unmaintained (transitive)
     "RUSTSEC-2025-0141", # bincode unmaintained (direct, migration pending)
+    "RUSTSEC-2026-0105", # core2 unmaintained (transitive via image -> rav1e AVIF encoder; awaiting upstream)
+    # The gtk-rs GTK3 binding family is unmaintained. It reaches us only through
+    # the Tauri and eframe Linux stacks; the whole ecosystem is mid-migration to
+    # GTK4/newer wry. Nothing actionable on our side yet — review each release.
+    "RUSTSEC-2024-0411",
+    "RUSTSEC-2024-0412",
+    "RUSTSEC-2024-0413",
+    "RUSTSEC-2024-0414",
+    "RUSTSEC-2024-0415",
+    "RUSTSEC-2024-0416",
+    "RUSTSEC-2024-0417",
+    "RUSTSEC-2024-0418",
+    "RUSTSEC-2024-0419",
+    "RUSTSEC-2024-0420",
+    "RUSTSEC-2024-0370", # proc-macro-error unmaintained (transitive, build-time only)
+    "RUSTSEC-2026-0192", # ttf-parser unmaintained (transitive via eframe font stack)
+    "RUSTSEC-2025-0075", # unic-* family unmaintained (transitive)
+    "RUSTSEC-2025-0080",
+    "RUSTSEC-2025-0081",
+    "RUSTSEC-2025-0098",
+    "RUSTSEC-2025-0100",
+    # quick-xml DoS-class issues (quadratic dup-attribute check / unbounded
+    # NsReader allocation). Reaches us transitively (Windows toast XML — app-
+    # generated, not attacker-controlled — and the Tauri/zbus stacks); no
+    # patched version is reachable within our dependents' semver ranges yet.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [licenses]
-allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC"]
-deny = ["GPL-3.0", "AGPL-3.0"]
-copyleft = "warn"
-allow-osi-fsf-free = true
-default = "deny"
+version = 2
+# v2 is allow-list only: anything not listed here fails the check (so GPL/AGPL
+# and friends are denied implicitly).
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "MPL-2.0",
+    "CDLA-Permissive-2.0",
+    "BSL-1.0",
+    "Unlicense",
+    "NCSA",
+    "Apache-2.0 WITH LLVM-exception",
+    "OFL-1.1",
+]
+
+# epaint's default fonts embed the Ubuntu Font License as a custom LicenseRef,
+# which can't be expressed in the allow list. Fonts only; permissive.
+exceptions = [
+    { allow = ["LicenseRef-UFL-1.0"], crate = "epaint_default_fonts" },
+]
 
 [bans]
-# Deny multiple versions of the same crate
 multiple-versions = "warn"
-# Deny wildcard versions
 wildcards = "warn"
-# Deny crates with security vulnerabilities
 skip-tree = []
 
 [sources]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -4,6 +4,7 @@ description = "P2PEM desktop (Tauri + webview) frontend — Phase 1 bridge over 
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 authors.workspace = true
 
 [lib]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,6 +4,7 @@ description = "Self-hosted Party/Community server for the Encrypted Messenger: c
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 authors.workspace = true
 
 [[bin]]


### PR DESCRIPTION
Prepares the v1.12.0 release — the first release that ships the desktop installers and everything from this quality campaign.

## Release prep
- Workspace version 1.11.1 → 1.12.0 (README badge updated; Tauri bundle version follows via Cargo.toml inheritance).
- CHANGELOG: Unreleased rolled into `[1.12.0] - 2026-07-05`. Highlights: community file sharing everywhere (desktop + TUI), community lifecycle (leave/rejoin/saved/pinning), desktop installers in releases, live transfer progress, real settings pane, unread badges, hosting CLI + docs, input caps + filename sanitization, 70% smaller webview bundle.

## Supply-chain hygiene (was silently broken)
- `cargo deny check` **errored on its own config** (pre-0.16 schema) — dependency auditing was non-functional. Migrated to schema v2; with it running again it caught **crossbeam-epoch RUSTSEC-2026-0204** (real vulnerability — fixed via update to 0.9.20). Remaining unpatchable transitive advisories are ignored with written justifications. All four checks green.
- Our four crates declared **no license**; they now inherit `MIT` from the workspace (matches LICENSE.md).
- gitleaks: allowlisted the single historical false positive (sequential-hex test vector) — scans are now clean by default.

## Verification
- `cargo nextest run --workspace` → **301 passed**
- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok
- `gitleaks detect` → no leaks
- clippy clean, fmt applied

**After merging**: push the tag to publish — `git tag v1.12.0 && git push origin v1.12.0`. The release pipeline will build the egui binaries **and the new desktop installers**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTyRxk3ruxo6kpkwTv5c4