### PR TITLE
fix: keep-alive pings, real Downloads dir, honest disconnect errors, release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Idle sessions no longer disconnect after 5 minutes.** Nothing ever sent
+  keep-alives, so both peers' receive-idle timers (300 s) tore down any
+  healthy-but-quiet conversation — one side logged "Receive idle timeout
+  (300s)", the other "early eof". The transport now sends an encrypted
+  keep-alive ping every 120 s (consumed silently on receipt, sharing the
+  replay-protected sequence space). Regression-tested with shrunken test
+  windows.
+- **Received files now land in your real Downloads folder.** The default
+  download directory was the *relative* path `Downloads`, resolved against the
+  process working directory — files were saved next to wherever the app was
+  launched from (or failed where that wasn't writable). The default now
+  resolves the OS Downloads folder, the temp dir default moved under the OS
+  temp dir, and configs saved by older builds are upgraded automatically on
+  load.
+- **Honest error after a peer disconnects.** Sending a message in an
+  established conversation whose session dropped showed "Connecting... please
+  wait" and silently dropped the message; it now says the message was not
+  delivered because the peer is disconnected.
+- **v1.12.0 release: desktop installers failed to build** — tauri-action
+  invokes `npm run tauri build`, and `package.json` had no `tauri` script. The
+  four classic binaries published fine; the installers ship with the next
+  release.
+
 ## [1.12.0] - 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,7 @@ dependencies = [
  "bincode",
  "chacha20poly1305",
  "chrono",
+ "directories",
  "ed25519-dalek",
  "hex",
  "hkdf",

--- a/client/src/app/chat_manager.rs
+++ b/client/src/app/chat_manager.rs
@@ -1118,15 +1118,30 @@ impl ChatManager {
 
         // One-to-one chat path
         if !has_session {
+            // An established conversation (fingerprint confirmed) without a
+            // session means the peer dropped — telling the user "connecting"
+            // there is a lie that hides why their message went nowhere.
+            let was_established = self
+                .chats
+                .get(&chat_id)
+                .is_some_and(|c| c.peer_fingerprint.is_some());
             tracing::warn!(
-                "No active session for 1:1 chat {} (mapped to {}) yet. Likely still connecting.",
+                "No active session for 1:1 chat {} (mapped to {}); established={}",
                 chat_id,
                 actual_session_chat_id,
+                was_established,
             );
-            self.add_toast(
-                ToastLevel::Info,
-                "Connecting... please wait before sending messages".to_string(),
-            );
+            if was_established {
+                self.add_toast(
+                    ToastLevel::Error,
+                    "Not delivered: the peer is disconnected. Reconnect (or ask them to) and try again.".to_string(),
+                );
+            } else {
+                self.add_toast(
+                    ToastLevel::Info,
+                    "Connecting... please wait before sending messages".to_string(),
+                );
+            }
             return Ok(()); // Do not error; just inform the user and skip sending
         }
 

--- a/client/src/app/persistence.rs
+++ b/client/src/app/persistence.rs
@@ -5,7 +5,7 @@ use chacha20poly1305::{
 };
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::types::{Chat, Config};
 use uuid::Uuid;
@@ -47,13 +47,16 @@ fn is_dangerous_path(p: &Path) -> bool {
     false
 }
 
-/// Sanitize loaded config: replace dangerous paths with defaults.
+/// Sanitize loaded config: replace dangerous paths with defaults, and upgrade
+/// the legacy **relative** defaults (`Downloads`, `temp`) that older builds
+/// persisted — those resolved against the process working directory, so
+/// received files landed next to wherever the app was launched from.
 fn sanitize_loaded_config(mut config: Config) -> Config {
-    if is_dangerous_path(&config.download_dir) {
-        config.download_dir = PathBuf::from("Downloads");
+    if is_dangerous_path(&config.download_dir) || config.download_dir.is_relative() {
+        config.download_dir = crate::types::default_download_dir();
     }
-    if is_dangerous_path(&config.temp_dir) {
-        config.temp_dir = PathBuf::from("temp");
+    if is_dangerous_path(&config.temp_dir) || config.temp_dir.is_relative() {
+        config.temp_dir = crate::types::default_temp_dir();
     }
     config
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,6 +41,7 @@ anyhow = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
+directories = { workspace = true }
 
 # Local peer discovery (mDNS/Bonjour)
 mdns-sd = { workspace = true }

--- a/core/src/network/session.rs
+++ b/core/src/network/session.rs
@@ -1128,10 +1128,20 @@ where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
     const RECV_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300); // 5 minutes
+                                                                                        // Keep-alive pings run well inside the peer's idle window (2 pings per
+                                                                                        // 300 s), so a quiet-but-healthy session is never torn down. Before this,
+                                                                                        // two connected peers who simply didn't type for five minutes were
+                                                                                        // disconnected by each side's receive timeout.
+    const KEEPALIVE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(120);
 
     // Key rotation constants
     const REKEY_MESSAGE_COUNT: u64 = 100; // Rekey every 100 messages
     const REKEY_TIME_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300); // 5 minutes
+
+    // Test hooks: integration tests shrink these windows (seconds) to verify the
+    // keep-alive behavior in wall-clock-realistic time. Never set in production.
+    let recv_idle_timeout = duration_from_env("P2PEM_TEST_IDLE_TIMEOUT_SECS", RECV_IDLE_TIMEOUT);
+    let keepalive_interval = duration_from_env("P2PEM_TEST_KEEPALIVE_SECS", KEEPALIVE_INTERVAL);
 
     // Track last valid sequence number to detect replays and out-of-order messages
     // This is enforced at the transport layer, not just in the app layer
@@ -1144,10 +1154,17 @@ where
     let mut messages_since_rekey: u64 = 0;
     let mut last_rekey_time = std::time::Instant::now();
 
+    // First tick only after a full interval (interval() would fire immediately).
+    let mut keepalive = tokio::time::interval_at(
+        tokio::time::Instant::now() + keepalive_interval,
+        keepalive_interval,
+    );
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
     loop {
         tokio::select! {
             // Receive from network with timeout
-            result = tokio::time::timeout(RECV_IDLE_TIMEOUT, recv_packet(&mut stream)) => {
+            result = tokio::time::timeout(recv_idle_timeout, recv_packet(&mut stream)) => {
                 match result {
                     Ok(Ok(encrypted)) => {
                         tracing::trace!("Received {} bytes encrypted", encrypted.len());
@@ -1178,6 +1195,13 @@ where
                                             last_rekey_time = std::time::Instant::now();
                                             tracing::info!("Session key rotated (received Rekey message)");
                                             // Don't emit the Rekey message to the app
+                                        } else if matches!(msg, ProtocolMessage::Ping { .. }) {
+                                            // Keep-alive: transport-level plumbing that
+                                            // only exists to defeat the idle timeout —
+                                            // consume it here. (The app layer also
+                                            // tolerates Ping for peers that still
+                                            // forward it.)
+                                            tracing::trace!("Keep-alive ping received");
                                         } else {
                                             // Track message count for rekeying
                                             messages_since_rekey += 1;
@@ -1217,7 +1241,7 @@ where
                     }
                     Err(_) => {
                         // Timeout occurred
-                        let err_msg = format!("Receive idle timeout ({}s)", RECV_IDLE_TIMEOUT.as_secs());
+                        let err_msg = format!("Receive idle timeout ({}s)", recv_idle_timeout.as_secs());
                         tracing::warn!("{}", err_msg);
                         let _ = to_app_tx.send(SessionEvent::Error(err_msg));
                         break;
@@ -1294,6 +1318,21 @@ where
                     messages_since_rekey += 1;
                 }
             }
+
+            // Keep-alive: ping on the shared outbound sequence so the peer's
+            // receive-idle timer resets even when nobody is typing.
+            _ = keepalive.tick() => {
+                sent_seq += 1;
+                let ping = ProtocolMessage::Ping { seq: sent_seq };
+                let encrypted = cipher.encrypt(&ping.to_plain_bytes(), Some(&transport_aad));
+                if let Err(e) = send_packet(&mut stream, &encrypted).await {
+                    let err_msg = format!("Network send error (keep-alive): {}", e);
+                    tracing::error!("{}", err_msg);
+                    let _ = to_app_tx.send(SessionEvent::Error(err_msg));
+                    break;
+                }
+                tracing::trace!("Keep-alive ping sent");
+            }
         }
     }
 
@@ -1302,6 +1341,17 @@ where
         .map_err(|e| anyhow!("Send error: {}", e))?;
 
     Ok(())
+}
+
+/// Read a duration override (whole seconds) from an environment variable, for
+/// integration tests that need realistic-wall-clock verification of the
+/// keep-alive/idle behavior. Falls back to `default` when unset or invalid.
+fn duration_from_env(var: &str, default: std::time::Duration) -> std::time::Duration {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(std::time::Duration::from_secs)
+        .unwrap_or(default)
 }
 
 #[cfg(test)]

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -251,11 +251,31 @@ pub enum NotificationSound {
     // Vibrate (for mobile, if applicable)
 }
 
+/// The user's real Downloads directory. The old default was the **relative**
+/// path `Downloads`, which resolved against the process working directory —
+/// received files landed next to wherever the app happened to be launched from
+/// (or failed outright when that location wasn't writable).
+pub fn default_download_dir() -> PathBuf {
+    if let Some(dirs) = directories::UserDirs::new() {
+        if let Some(dl) = dirs.download_dir() {
+            return dl.to_path_buf();
+        }
+        return dirs.home_dir().join("Downloads");
+    }
+    PathBuf::from("Downloads")
+}
+
+/// A per-app scratch directory under the OS temp dir (absolute, always
+/// writable), replacing the old relative `temp` default.
+pub fn default_temp_dir() -> PathBuf {
+    std::env::temp_dir().join("chat-p2p")
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
-            download_dir: PathBuf::from("Downloads"),
-            temp_dir: PathBuf::from("temp"),
+            download_dir: default_download_dir(),
+            temp_dir: default_temp_dir(),
             auto_accept_files: false,
             enable_notifications: true,
             enable_typing_indicators: true,

--- a/core/tests/session_e2e.rs
+++ b/core/tests/session_e2e.rs
@@ -237,14 +237,23 @@ async fn full_pipeline_handshake_messages_typing_file_and_disconnect() {
         ProtocolMessage::FileEnd { .. }
     ));
 
-    // --- Keep-alive ping ---
+    // --- Keep-alive ping: transport plumbing, consumed silently ---
+    // A Ping must keep the session healthy but never surface to the app: the
+    // very next app-visible message after it is the following Text, not the Ping.
     host.outbound
         .send(ProtocolMessage::Ping { seq: 7 })
         .unwrap();
-    assert!(matches!(
-        next_message(&mut client.events, "client").await,
-        ProtocolMessage::Ping { .. }
-    ));
+    host.outbound
+        .send(ProtocolMessage::Text {
+            text: "after-ping".into(),
+            timestamp: 99,
+            seq: 8,
+        })
+        .unwrap();
+    match next_message(&mut client.events, "client").await {
+        ProtocolMessage::Text { text, .. } => assert_eq!(text, "after-ping"),
+        other => panic!("ping must be consumed by the transport, got {other:?}"),
+    }
 
     // --- Disconnect: tearing down the client makes the host observe the drop ---
     client.handle.abort();
@@ -371,6 +380,57 @@ async fn reach_ready(host: &mut Peer, client: &mut Peer) {
         matches!(ev, SessionEvent::Ready)
     })
     .await;
+}
+
+/// Regression test for the 5-minute idle disconnect: nothing sent keep-alives,
+/// so both sides' receive-idle timers tore down any healthy-but-quiet session
+/// (each peer saw either "Receive idle timeout (300s)" or the other side's
+/// resulting "early eof"). With the transport's keep-alive pings, an idle
+/// session must survive past the idle window and still deliver messages.
+/// The env hooks shrink the windows so this verifies in seconds: keep-alive
+/// every 1 s against a 3 s idle timeout, then 6 s of pure silence.
+#[tokio::test]
+async fn idle_session_survives_past_the_idle_timeout() {
+    // Read at message-loop startup, so set before the pair connects. nextest
+    // runs each test in its own process, so this cannot leak across tests.
+    std::env::set_var("P2PEM_TEST_KEEPALIVE_SECS", "1");
+    std::env::set_var("P2PEM_TEST_IDLE_TIMEOUT_SECS", "3");
+
+    let (mut host, mut client) = connect_pair().await;
+    reach_ready(&mut host, &mut client).await;
+
+    // Twice the idle window with neither side sending anything.
+    tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+
+    // The session must still be alive and deliver in both directions. If the
+    // idle timer had fired, the event stream would yield Error/Disconnected
+    // here and next_message would fail the test.
+    host.outbound
+        .send(ProtocolMessage::Text {
+            text: "still here".into(),
+            timestamp: 1,
+            seq: 1,
+        })
+        .unwrap();
+    match next_message(&mut client.events, "client").await {
+        ProtocolMessage::Text { text, .. } => assert_eq!(text, "still here"),
+        other => panic!("expected Text after idle period, got {other:?}"),
+    }
+    client
+        .outbound
+        .send(ProtocolMessage::Text {
+            text: "me too".into(),
+            timestamp: 2,
+            seq: 1,
+        })
+        .unwrap();
+    match next_message(&mut host.events, "host").await {
+        ProtocolMessage::Text { text, .. } => assert_eq!(text, "me too"),
+        other => panic!("expected Text after idle period, got {other:?}"),
+    }
+
+    host.handle.abort();
+    client.handle.abort();
 }
 
 /// Regression test for the rekey/replay desync: the transport rekeys after

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "tauri": "tauri"
   },
   "dependencies": {
     "@tauri-apps/api": "~2.11.0",


### PR DESCRIPTION
Four bugs found by digging through real two-peer session logs (thanks to the field test).

## 1. Idle sessions disconnected after exactly 5 minutes
The logs show it twice: last activity 15:11:08 → `Receive idle timeout (300s)` at 15:16:08; the earlier `early eof` was the peer's side doing the same. **Nothing ever sent keep-alives** — the `Ping` message existed in the protocol but had zero senders. The transport now pings every 120 s on the shared replay-protected sequence; received pings are consumed silently (older peers' app layer already tolerates them — verified). New regression test uses env-shrunken windows (`P2PEM_TEST_*`, nextest = process-per-test) to prove an idle session survives twice the idle window and still delivers both ways.

## 2. Files saved to a relative `Downloads` folder
Log: `File saved to: "Downloads\AI Alignment Research_ Sources.pdf"` — that's `<cwd>\Downloads`, not the user's Downloads. Default now resolves the real OS Downloads dir; `temp_dir` moved under the OS temp dir; configs persisted by older builds are upgraded on load.

## 3. Misleading state after a peer disconnects
Sending in an established conversation whose session dropped toasted "Connecting... please wait" and silently dropped the message (visible in the log at 15:10:00). Established chats now get "Not delivered: the peer is disconnected."

## 4. v1.12.0 desktop installers failed to build
All four `build-desktop` release jobs failed with `npm error Missing script: "tauri"` — tauri-action invokes `npm run tauri build`. Script added; `npm run tauri -- --version` verified locally. The classic binaries in v1.12.0 published fine; installers ship with v1.12.1.

## Verification
- `cargo nextest run --workspace` → **302 passed, 0 skipped** (incl. the new idle-survival e2e)
- clippy `-D warnings` clean; fmt applied

After merge: tag `v1.12.1` to ship the fixes + the first desktop installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTyRxk3ruxo6kpkwTv5c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Idle chats now stay connected longer thanks to automatic keep-alives.
  * Files you receive now open in the system Downloads folder, with older settings updated automatically.
  * Messages sent after the other side disconnects now clearly show as not delivered.
  * Desktop installer builds now complete successfully again.
* **New Features**
  * Session handling is more resilient during quiet periods.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->