### PR TITLE
fix: only report a file as sent once its final frame is on the wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **"File sent" is now confirmed at the wire, not at the queue.** Sending a
+  file reported success as soon as its frames were queued on the session —
+  the transfer could still be in flight (or die with the connection) while
+  the sender saw "File sent". The session now reports when the file's final
+  frame is actually written to the socket; only then does the success toast
+  appear, and a disconnect with sends still pending shows an honest
+  "File may not have been delivered" error instead.
+
 ## [1.12.1] - 2026-07-07
 
 ### Fixed

--- a/client/src/app/chat_manager.rs
+++ b/client/src/app/chat_manager.rs
@@ -8,7 +8,7 @@
 //! - Invite link generation and parsing (including QR codes)
 
 use anyhow::{anyhow, bail, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -44,6 +44,9 @@ pub struct ChatManager {
     /// When a message is sent to incoming_chat_id, it's forwarded to the parent_session_chat_id's session.
     chat_id_mapping: HashMap<Uuid, Uuid>,
     active_transfers: HashMap<Uuid, FileTransferState>,
+    /// Outgoing files queued on a session but whose final frame has not hit the
+    /// wire yet (FIFO per chat; resolved by `SessionEvent::FileSendComplete`).
+    pending_file_sends: HashMap<Uuid, VecDeque<String>>,
     #[allow(dead_code)] // Reserved for future file transfer implementation
     incoming_files: HashMap<Uuid, IncomingFileSync>,
     incoming_text_messages: HashMap<(Uuid, Uuid), IncomingTextMessage>,
@@ -321,6 +324,7 @@ impl ChatManager {
             session_events: HashMap::new(),
             chat_id_mapping: HashMap::new(),
             active_transfers: HashMap::new(),
+            pending_file_sends: HashMap::new(),
             incoming_files: HashMap::new(),
             incoming_text_messages: HashMap::new(),
             toasts: Vec::new(),
@@ -1485,10 +1489,10 @@ impl ChatManager {
         use tokio::io::AsyncReadExt;
 
         tracing::info!(chat_id = %chat_id, path = %path.display().to_string(), "Preparing to send file");
-        let actual_id = self.chat_id_mapping.get(&chat_id).unwrap_or(&chat_id);
+        let session_id = *self.chat_id_mapping.get(&chat_id).unwrap_or(&chat_id);
         let sender = self
             .sessions
-            .get(actual_id)
+            .get(&session_id)
             .map(|s| s.from_app_tx.clone())
             .ok_or_else(|| anyhow!("Session not found"))?;
 
@@ -1533,7 +1537,7 @@ impl ChatManager {
         // Send end marker with the next monotonic sequence value.
         chat.send_seq += 1;
         sender.send(ProtocolMessage::FileEnd { seq: chat.send_seq })?;
-        tracing::info!(file = %filename, total_bytes = %file_size, "File send complete");
+        tracing::info!(file = %filename, total_bytes = %file_size, "File queued for sending");
 
         // Add to local history.
         chat.messages.push(Message {
@@ -1547,9 +1551,34 @@ impl ChatManager {
             timestamp: chrono::Utc::now(),
         });
 
-        self.add_toast(ToastLevel::Success, format!("File sent: {}", filename));
+        // Queueing is not delivery: the success toast waits for the session to
+        // report the final frame on the wire (SessionEvent::FileSendComplete).
+        // File frames drain FIFO per session, so a per-session queue correlates;
+        // keyed by session id because that is where the event will arrive.
+        self.pending_file_sends
+            .entry(session_id)
+            .or_default()
+            .push_back(filename);
 
         Ok(())
+    }
+
+    /// Fail all not-yet-confirmed outgoing file sends for a chat (session died
+    /// before their final frame was written) with an honest error toast.
+    fn fail_pending_file_sends(&mut self, chat_id: Uuid, reason: &str) {
+        let Some(pending) = self.pending_file_sends.remove(&chat_id) else {
+            return;
+        };
+        for filename in pending {
+            tracing::warn!(file = %filename, reason = %reason, "Outgoing file send interrupted");
+            self.add_toast(
+                ToastLevel::Error,
+                format!(
+                    "File may not have been delivered ({}): {}",
+                    reason, filename
+                ),
+            );
+        }
     }
 
     /// Poll and process all pending session events
@@ -2122,9 +2151,26 @@ impl ChatManager {
                 }
             }
 
+            SessionEvent::FileSendComplete { seq } => {
+                match self
+                    .pending_file_sends
+                    .get_mut(&chat_id)
+                    .and_then(|q| q.pop_front())
+                {
+                    Some(filename) => {
+                        tracing::info!(file = %filename, seq = %seq, "File send complete (final frame on the wire)");
+                        self.add_toast(ToastLevel::Success, format!("File sent: {}", filename));
+                    }
+                    None => {
+                        tracing::warn!(seq = %seq, "FileSendComplete with no pending file send");
+                    }
+                }
+            }
+
             SessionEvent::Disconnected => {
                 tracing::warn!("Session {} disconnected", chat_id);
                 self.add_toast(ToastLevel::Warning, "Connection lost".to_string());
+                self.fail_pending_file_sends(chat_id, "connection lost");
 
                 // Clean up session
                 self.sessions.remove(&chat_id);
@@ -2135,6 +2181,7 @@ impl ChatManager {
             SessionEvent::Error(err) => {
                 tracing::error!("Session {} error: {}", chat_id, err);
                 self.add_toast(ToastLevel::Error, format!("Connection error: {}", err));
+                self.fail_pending_file_sends(chat_id, "connection error");
             }
 
             SessionEvent::Warning(msg) => {
@@ -2953,6 +3000,70 @@ mod tests {
         assert!(
             seqs.windows(2).all(|w| w[1] == w[0] + 1),
             "File transfer messages must use strictly increasing sequence numbers"
+        );
+    }
+
+    /// Queueing frames on the session is not delivery: the "File sent" toast
+    /// must wait for the session's wire-level confirmation event.
+    #[tokio::test]
+    async fn file_sent_toast_waits_for_wire_confirmation() {
+        let mut mgr = ChatManager::new(Config::default());
+        let chat_id = Uuid::new_v4();
+        mgr.create_local_chat_for_test(chat_id, "Honest Send".to_string());
+
+        let (from_app_tx, _from_app_rx) = mpsc::unbounded_channel();
+        mgr.sessions.insert(chat_id, SessionHandle { from_app_tx });
+
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp_file.path(), b"payload").unwrap();
+        mgr.send_file(chat_id, temp_file.path().to_path_buf())
+            .await
+            .expect("send_file should succeed");
+
+        assert!(
+            !mgr.toasts.iter().any(|t| t.message.contains("File sent")),
+            "success toast must not fire before the wire confirmation"
+        );
+
+        mgr.handle_session_event(chat_id, SessionEvent::FileSendComplete { seq: 42 });
+        assert!(
+            mgr.toasts.iter().any(|t| t.message.contains("File sent")),
+            "success toast must fire once the final frame is on the wire"
+        );
+    }
+
+    /// If the session dies before the final frame is written, the user must be
+    /// told the file may not have arrived — not shown a success message.
+    #[tokio::test]
+    async fn disconnect_fails_pending_file_sends_honestly() {
+        let mut mgr = ChatManager::new(Config::default());
+        let chat_id = Uuid::new_v4();
+        mgr.create_local_chat_for_test(chat_id, "Interrupted Send".to_string());
+
+        let (from_app_tx, _from_app_rx) = mpsc::unbounded_channel();
+        mgr.sessions.insert(chat_id, SessionHandle { from_app_tx });
+
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp_file.path(), b"payload").unwrap();
+        mgr.send_file(chat_id, temp_file.path().to_path_buf())
+            .await
+            .expect("send_file should succeed");
+
+        mgr.handle_session_event(chat_id, SessionEvent::Disconnected);
+
+        assert!(
+            !mgr.toasts.iter().any(|t| t.message.contains("File sent")),
+            "no success toast after a disconnect"
+        );
+        assert!(
+            mgr.toasts
+                .iter()
+                .any(|t| t.message.contains("may not have been delivered")),
+            "the user must see an honest delivery warning"
+        );
+        assert!(
+            !mgr.pending_file_sends.contains_key(&chat_id),
+            "pending sends must be cleared on disconnect"
         );
     }
 

--- a/core/src/network/session.rs
+++ b/core/src/network/session.rs
@@ -1316,6 +1316,11 @@ where
                     tracing::debug!("Message sent successfully");
                     // Track sent messages for rekeying
                     messages_since_rekey += 1;
+                    // The file's last frame just hit the wire: tell the app the
+                    // transfer is genuinely done (queueing is not delivery).
+                    if let ProtocolMessage::FileEnd { seq } = msg {
+                        let _ = to_app_tx.send(SessionEvent::FileSendComplete { seq });
+                    }
                 }
             }
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -200,6 +200,11 @@ pub enum SessionEvent {
     },
     Ready,
     MessageReceived(crate::core::ProtocolMessage),
+    /// The final frame of an outgoing file transfer (`FileEnd` with this seq)
+    /// was written to the wire — only now is the transfer actually complete.
+    FileSendComplete {
+        seq: u64,
+    },
     Disconnected,
     Error(String),
     Warning(String),

--- a/core/tests/session_e2e.rs
+++ b/core/tests/session_e2e.rs
@@ -237,6 +237,15 @@ async fn full_pipeline_handshake_messages_typing_file_and_disconnect() {
         ProtocolMessage::FileEnd { .. }
     ));
 
+    // The SENDER must be told when the file's final frame actually hit the
+    // wire — queueing is not delivery. (The seq in the event is the transport
+    // sequence the loop stamped, not the app-supplied one, so only the variant
+    // is asserted.)
+    wait_until(&mut host.events, "host", |ev| {
+        matches!(ev, SessionEvent::FileSendComplete { .. })
+    })
+    .await;
+
     // --- Keep-alive ping: transport plumbing, consumed silently ---
     // A Ping must keep the session healthy but never surface to the app: the
     // very next app-visible message after it is the following Text, not the Ping.


### PR DESCRIPTION
## Problem

`send_file` queues every frame into the session's **unbounded** channel and returns — but it logged `File send complete` and toasted **"File sent"** at queue time. The wire transfer could still be running, or the connection could drop halfway, and the user would still see a success message. (Spotted in the field-test logs from the v1.12.x bug hunt.)

## Fix

- **`SessionEvent::FileSendComplete { seq }`** — emitted by the session message loop *right after* the `FileEnd` frame is actually written to the socket.
- **ChatManager** keeps a per-session FIFO of queued file sends (frames drain in order, so the queue correlates exactly) and only toasts "File sent" on the confirmation event.
- **Disconnect/error with sends pending** → honest `File may not have been delivered (connection lost): <name>` error toast instead of a stale success.

All three UIs (egui, TUI, desktop) render ChatManager toasts, so they all inherit the honest behavior.

## Tests

- e2e: sender receives `FileSendComplete` after `FileEnd` crosses the wire (`full_pipeline_...`).
- Unit: `file_sent_toast_waits_for_wire_confirmation`, `disconnect_fails_pending_file_sends_honestly`.
- `cargo nextest run --workspace`: **304/304 pass** · clippy clean · fmt applied · gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTyRxk3ruxo6kpkwTv5c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File transfer notifications now appear only after the final file frame is confirmed delivered, reducing false “sent” confirmations.
  * If a session disconnects or errors during a file send, pending transfers are now cleared and shown as failed instead of successful.
* **Tests**
  * Updated end-to-end coverage to verify file-send completion timing and disconnect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->