### PR TITLE
ci: unify release asset naming under the P2PEM brand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,19 +58,26 @@ jobs:
 
       - name: Compile Installer
         run: |
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion="${{ github.ref_name }}" /O"Output" /F"Messenger-Setup-${{ github.ref_name }}" setup.iss
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion="$version" /O"Output" /F"P2PEM-Classic_${version}_x64-setup" setup.iss
 
       - name: Upload Installer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" "./Output/Messenger-Setup-${{ github.ref_name }}.exe" --repo "${{ github.repository }}" --clobber
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          gh release upload "${{ github.ref_name }}" "./Output/P2PEM-Classic_${version}_x64-setup.exe" --repo "${{ github.repository }}" --clobber
 
   build-macos:
     needs: create-release
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+        include:
+          - target: x86_64-apple-darwin
+            arch: x64
+          - target: aarch64-apple-darwin
+            arch: aarch64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -124,12 +131,15 @@ jobs:
 
       - name: Create DMG
         run: |
-          hdiutil create -volname "Messenger" -srcfolder Messenger.app -ov -format UDZO messenger-${{ matrix.target }}.dmg
+          VERSION="${GITHUB_REF_NAME#v}"
+          hdiutil create -volname "Messenger" -srcfolder Messenger.app -ov -format UDZO "P2PEM-Classic_${VERSION}_macos-${{ matrix.arch }}.dmg"
 
       - name: Upload DMG
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" "./messenger-${{ matrix.target }}.dmg#Messenger-macOS-${{ matrix.target }}-${{ github.ref_name }}.dmg" --repo "${{ github.repository }}" --clobber
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh release upload "${{ github.ref_name }}" "./P2PEM-Classic_${VERSION}_macos-${{ matrix.arch }}.dmg" --repo "${{ github.repository }}" --clobber
 
   # The new Tauri desktop app (P2PEM). Builds the platform installers with
   # Tauri's own bundler and attaches them to the same release as the classic
@@ -219,12 +229,15 @@ jobs:
 
       - name: Create Tarball
         run: |
-          mkdir -p messenger-linux
-          cp target/release/encodeur_rsa_rust messenger-linux/messenger
-          cp README.md LICENSE.md messenger-linux/
-          tar -czvf messenger-linux-${{ github.ref_name }}.tar.gz messenger-linux/
+          VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p p2pem-classic
+          cp target/release/encodeur_rsa_rust p2pem-classic/messenger
+          cp README.md LICENSE.md p2pem-classic/
+          tar -czvf "P2PEM-Classic_${VERSION}_linux-x64.tar.gz" p2pem-classic/
 
       - name: Upload Tarball
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" "./messenger-linux-${{ github.ref_name }}.tar.gz#Messenger-Linux-${{ github.ref_name }}.tar.gz" --repo "${{ github.repository }}" --clobber
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh release upload "${{ github.ref_name }}" "./P2PEM-Classic_${VERSION}_linux-x64.tar.gz" --repo "${{ github.repository }}" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,15 @@ jobs:
 
       - name: Compile Installer
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v")
+          $version = $env:GITHUB_REF_NAME.TrimStart("v")
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion="$version" /O"Output" /F"P2PEM-Classic_${version}_x64-setup" setup.iss
 
       - name: Upload Installer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v")
-          gh release upload "${{ github.ref_name }}" "./Output/P2PEM-Classic_${version}_x64-setup.exe" --repo "${{ github.repository }}" --clobber
+          $version = $env:GITHUB_REF_NAME.TrimStart("v")
+          gh release upload "$env:GITHUB_REF_NAME" "./Output/P2PEM-Classic_${version}_x64-setup.exe" --repo "$env:GITHUB_REPOSITORY" --clobber
 
   build-macos:
     needs: create-release
@@ -139,7 +139,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          gh release upload "${{ github.ref_name }}" "./P2PEM-Classic_${VERSION}_macos-${{ matrix.arch }}.dmg" --repo "${{ github.repository }}" --clobber
+          gh release upload "$GITHUB_REF_NAME" "./P2PEM-Classic_${VERSION}_macos-${{ matrix.arch }}.dmg" --repo "$GITHUB_REPOSITORY" --clobber
 
   # The new Tauri desktop app (P2PEM). Builds the platform installers with
   # Tauri's own bundler and attaches them to the same release as the classic
@@ -240,4 +240,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          gh release upload "${{ github.ref_name }}" "./P2PEM-Classic_${VERSION}_linux-x64.tar.gz" --repo "${{ github.repository }}" --clobber
+          gh release upload "$GITHUB_REF_NAME" "./P2PEM-Classic_${VERSION}_linux-x64.tar.gz" --repo "$GITHUB_REPOSITORY" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ predate tagged releases.
 
 ### Changed
 
+- **Release assets renamed to one consistent scheme.** The classic egui
+  artifacts drop the mixed `Messenger-Setup-v*` / `messenger-*` naming for
+  `P2PEM-Classic_<version>_<platform>-<arch>.<ext>` (e.g.
+  `P2PEM-Classic_1.13.0_x64-setup.exe`, `P2PEM-Classic_1.13.0_macos-aarch64.dmg`,
+  `P2PEM-Classic_1.13.0_linux-x64.tar.gz`), matching the Tauri app's
+  `P2PEM_<version>_*` convention on the same release page. The versionless
+  `P2PEM_*.app.tar.gz` archives are no longer published (the `.dmg` covers
+  macOS; the bare `.app` target is excluded from the bundle list).
 - **Documentation restructured.** The numbered docs are renamed
   (`docs/03_architecture.md` → `docs/architecture.md`, `docs/04_protocol.md` →
   `docs/protocol.md`, `docs/05_platform_spec.md` → `docs/platform_spec.md`);

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "rpm", "appimage", "msi", "nsis", "dmg"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -18,10 +18,13 @@ By the end of this tutorial you will have:
 
 Use the latest release from GitHub:
 
-- Windows: download `Messenger-Setup-v*.exe`
-- macOS Intel: download `messenger-x86_64-apple-darwin.dmg`
-- macOS Apple Silicon: download `messenger-aarch64-apple-darwin.dmg`
-- Linux: download `messenger-linux-v*.tar.gz`
+- Windows: download `P2PEM-Classic_<version>_x64-setup.exe`
+- macOS Intel: download `P2PEM-Classic_<version>_macos-x64.dmg`
+- macOS Apple Silicon: download `P2PEM-Classic_<version>_macos-aarch64.dmg`
+- Linux: download `P2PEM-Classic_<version>_linux-x64.tar.gz`
+
+(The `P2PEM_<version>_*` assets on the same page are the newer Tauri desktop
+app; see the [User Guide](USER_GUIDE.md#installation) for the full list.)
 
 If you prefer to build from source:
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -10,10 +10,21 @@ If you want the fastest onboarding path instead of the full reference, start wit
 
 Download the latest platform asset from the [GitHub Releases](https://github.com/fibo3090-code/secure-p2p-chat/releases) page.
 
-- Windows: `Messenger-Setup-v*.exe`
-- macOS Intel: `messenger-x86_64-apple-darwin.dmg`
-- macOS Apple Silicon: `messenger-aarch64-apple-darwin.dmg`
-- Linux: `messenger-linux-v*.tar.gz`
+Classic egui app:
+
+- Windows: `P2PEM-Classic_<version>_x64-setup.exe`
+- macOS Intel: `P2PEM-Classic_<version>_macos-x64.dmg`
+- macOS Apple Silicon: `P2PEM-Classic_<version>_macos-aarch64.dmg`
+- Linux: `P2PEM-Classic_<version>_linux-x64.tar.gz`
+
+New Tauri desktop app (P2PEM):
+
+- Windows: `P2PEM_<version>_x64-setup.exe` (NSIS) or `P2PEM_<version>_x64_en-US.msi`
+- macOS: `P2PEM_<version>_aarch64.dmg` or `P2PEM_<version>_x64.dmg`
+- Linux: `P2PEM_<version>_amd64.deb`, `P2PEM_<version>_amd64.AppImage`, or `P2PEM-<version>-1.x86_64.rpm`
+
+Releases older than 1.13 used different asset names (`Messenger-Setup-v*.exe`,
+`messenger-*.dmg`, `messenger-linux-v*.tar.gz`) for the classic app.
 
 ### Build from source
 


### PR DESCRIPTION
## Summary

- Release pages currently mix three naming conventions side by side: lowercase, unversioned egui artifacts whose display label differs from the real filename (`messenger-aarch64-apple-darwin.dmg` labeled `Messenger-macOS-aarch64-apple-darwin-v1.12.1.dmg`), a double-versioned Windows installer (`Messenger-Setup-v1.12.1.exe`), the Tauri app's standard `P2PEM_1.12.1_*` names, and versionless `P2PEM_x64.app.tar.gz` archives.
- Classic egui artifacts now follow the same scheme as the Tauri app: `P2PEM-Classic_<version>_<platform>-<arch>.<ext>` (`P2PEM-Classic_1.13.0_x64-setup.exe`, `P2PEM-Classic_1.13.0_macos-aarch64.dmg`, `P2PEM-Classic_1.13.0_linux-x64.tar.gz`), version stripped of the tag's leading `v`, and no more `gh release upload "file#Label"` hacks — the filename is the display name.
- `tauri.conf.json`'s bundle target list replaces `"all"` with the explicit installer set (`deb`, `rpm`, `appimage`, `msi`, `nsis`, `dmg`), which stops publishing the bare-`.app` tarballs that carried no version and duplicated the `.dmg`.
- The Inno installer's displayed version also drops the leading `v` (was shown as `v1.12.1` in Add/Remove Programs).
- Why this scope: filename changes only — no change to what is built, the installed app identity (Inno `AppId`, install dir), or the Tauri product name.

## User Impact

- Future release pages show one coherent asset family: `P2PEM_<version>_*` (Tauri desktop app) and `P2PEM-Classic_<version>_*` (legacy egui app), instead of three naming styles.
- Anyone scripting downloads against the old asset names must update their patterns; the User Guide documents both the new names and the pre-1.13 names for older releases.
- Two fewer confusing assets per release (the versionless `.app.tar.gz` pair).

## Verification

- [x] `python -c "yaml.safe_load(...)"` on `release.yml` and `json.load` on `tauri.conf.json` — both parse
- [x] `cargo check -p p2pem-desktop` — tauri-build accepts the new explicit bundle target list
- [x] `rg` sweep for the old asset names — remaining references are only the intentional "older releases" note in the User Guide
- [ ] Full end-to-end validation requires the next tagged release (the workflow only runs on `v*` tags); flagged rather than simulated

## Docs And Release Notes

- [x] `docs/USER_GUIDE.md` and `docs/TUTORIAL.md` install sections updated to the new asset names (with the legacy names noted for pre-1.13 releases)
- [x] `CHANGELOG.md` Unreleased entry added
- [x] No security or protocol implications


---
_Generated by [Claude Code](https://claude.ai/code/session_01EgKKFA4jtYxrBouS2gtfui)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release downloads now use consistent `P2PEM-Classic_<version>_<platform>-<arch>` filenames across Windows, macOS, and Linux.
  * Platform-specific installer formats are explicitly supported.

* **Documentation**
  * Updated installation instructions and the user guide with the latest download names and formats.
  * Clarified the distinction between Classic and newer desktop app releases.

* **Bug Fixes**
  * Improved release version handling to ensure packaged assets use the correct version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->