### PR TITLE
Debt & roadmap batch: crate rename, invite expiry, transfer progress, desktop tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,28 @@ jobs:
       - name: Run Tests
         run: cargo test --workspace
 
+  frontend:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: desktop
+
+      - name: Build
+        run: npm run build
+        working-directory: desktop
+
   build-verification:
     name: Build Verification
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
         run: npm ci
         working-directory: desktop
 
+      - name: Test
+        run: npm test
+        working-directory: desktop
+
       - name: Build
         run: npm run build
         working-directory: desktop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build Release
-        run: cargo build --release --locked -p encodeur_rsa_rust
+        run: cargo build --release --locked -p p2pem-classic
 
       - name: Prepare Dist
         run: |
           mkdir dist
-          cp target/release/encodeur_rsa_rust.exe dist/
+          cp target/release/p2pem-classic.exe dist/
           cp app-icon.ico dist/
           cp README.md dist/
           cp LICENSE.md dist/
@@ -92,13 +92,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --release --locked --target ${{ matrix.target }} -p encodeur_rsa_rust
+        run: cargo build --release --locked --target ${{ matrix.target }} -p p2pem-classic
 
       - name: Create App Bundle
         run: |
           mkdir -p Messenger.app/Contents/MacOS
           mkdir -p Messenger.app/Contents/Resources
-          cp target/${{ matrix.target }}/release/encodeur_rsa_rust Messenger.app/Contents/MacOS/Messenger
+          cp target/${{ matrix.target }}/release/p2pem-classic Messenger.app/Contents/MacOS/Messenger
           chmod +x Messenger.app/Contents/MacOS/Messenger
           
           # macOS bundles use .icns, not .ico - use the Tauri app's icon set
@@ -225,13 +225,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --release --locked -p encodeur_rsa_rust
+        run: cargo build --release --locked -p p2pem-classic
 
       - name: Create Tarball
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p p2pem-classic
-          cp target/release/encodeur_rsa_rust p2pem-classic/messenger
+          cp target/release/p2pem-classic p2pem-classic/p2pem-classic
           cp README.md LICENSE.md p2pem-classic/
           tar -czvf "P2PEM-Classic_${VERSION}_linux-x64.tar.gz" p2pem-classic/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,27 @@ predate tagged releases.
   for brand and theme colors; a test asserts the egui palette matches it, so
   the token file and the UI can no longer drift apart silently.
 
+- **Signed invites now expire.** A signed invite older than 30 days is
+  rejected at import with a clear error (the timestamp is covered by the
+  invite's signature, so it cannot be back- or forward-dated without breaking
+  verification; future-dated invites beyond a 1-hour clock-skew allowance are
+  rejected too). Legacy v1 unsigned invites carry no timestamp and still
+  import with the existing warning.
+
 ### Changed
 
+- **Client crate renamed `encodeur_rsa_rust` → `p2pem-classic`.** The last
+  RSA-era name in the repo is gone: the package, library, and binary are now
+  `p2pem-classic` (matching the release artifacts), so a task manager or `ps`
+  shows `p2pem-classic` instead of `encodeur_rsa_rust`. Build commands change
+  accordingly (`cargo build -p p2pem-classic`; the binary lands at
+  `target/release/p2pem-classic`), and the Linux tarball's inner binary is
+  `p2pem-classic` rather than `messenger`. Data directories are unchanged
+  (identity/history still load from the same location); `RUST_LOG` filters
+  that targeted `encodeur_rsa_rust=` must switch to `p2pem_classic=`.
+- **CI now builds the React frontend.** A `Frontend Build` job (`npm ci` +
+  `npm run build` in `desktop/`) joins the pipeline; previously a broken
+  frontend could pass CI because the committed `desktop/dist/` masked it.
 - **Release assets renamed to one consistent scheme.** The classic egui
   artifacts drop the mixed `Messenger-Setup-v*` / `messenger-*` naming for
   `P2PEM-Classic_<version>_<platform>-<arch>.<ext>` (e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ predate tagged releases.
   for brand and theme colors; a test asserts the egui palette matches it, so
   the token file and the UI can no longer drift apart silently.
 
+- **File-transfer progress in every UI.** The egui GUI shows a live progress
+  bar above the chat input and the TUI shows a percentage in the message-view
+  title, matching the transfer bar the desktop app already had. (Wire-level
+  cancellation is planned separately — it needs a protocol message, see the
+  platform spec backlog.)
+- **First automated tests for the desktop frontend.** Vitest covers the pure
+  logic modules (`colorgrid`, `partyUnread`, `themes`), and `npm test` runs in
+  CI's new Frontend Build job.
 - **Signed invites now expire.** A signed invite older than 30 days is
   rejected at import with a clear error (the timestamp is covered by the
   invite's signature, so it cannot be back- or forward-dated without breaking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Cargo **workspace** with four members (root `src/` and `tests/` are vestigial â€
 | Crate | Path | What it is |
 |-------|------|------------|
 | `messenger-core` | `core/` | Crypto, protocol, network/session, transfer, identity, shared `types.rs` (UI-agnostic) |
-| `encodeur_rsa_rust` | `client/` | The app: ChatManager + egui GUI + ratatui TUI (lib + binary) |
+| `p2pem-classic` | `client/` | The app: ChatManager + egui GUI + ratatui TUI (lib + binary) |
 | `messenger-server` | `server/` | Party/Community server (hub, dispatch, connection, state) |
 | `p2pem-desktop` | `desktop/src-tauri/` | **New** Tauri 2 shell wrapping the React/Vite web UI in `desktop/src/` |
 
@@ -42,7 +42,7 @@ cd desktop && npx tauri build    # packaged desktop build
 cd desktop && npm run dev        # frontend only, in a plain browser (uses the dev mock â€” see bridge.js)
 
 # Logging
-RUST_LOG="info,encodeur_rsa_rust=debug" cargo run
+RUST_LOG="info,p2pem_classic=debug" cargo run
 
 # Windows packaging (egui binary)
 ./build-and-package.ps1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,46 +2221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encodeur_rsa_rust"
-version = "1.12.1"
-dependencies = [
- "anyhow",
- "arboard",
- "base64 0.21.7",
- "chacha20poly1305",
- "chrono",
- "clap",
- "directories",
- "eframe",
- "egui",
- "egui_commonmark",
- "egui_tracing",
- "emojis",
- "hex",
- "image",
- "messenger-core",
- "notify-rust",
- "open",
- "proptest",
- "qrcode",
- "rand 0.8.6",
- "ratatui",
- "ratatui-crossterm",
- "rfd",
- "rsa",
- "serde",
- "serde_json",
- "tempfile",
- "tokio",
- "tokio-test",
- "tracing",
- "tracing-subscriber",
- "unicode-width 0.2.2",
- "uuid",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5044,14 +5004,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "p2pem-classic"
+version = "1.12.1"
+dependencies = [
+ "anyhow",
+ "arboard",
+ "base64 0.21.7",
+ "chacha20poly1305",
+ "chrono",
+ "clap",
+ "directories",
+ "eframe",
+ "egui",
+ "egui_commonmark",
+ "egui_tracing",
+ "emojis",
+ "hex",
+ "image",
+ "messenger-core",
+ "notify-rust",
+ "open",
+ "proptest",
+ "qrcode",
+ "rand 0.8.6",
+ "ratatui",
+ "ratatui-crossterm",
+ "rfd",
+ "rsa",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "tracing-subscriber",
+ "unicode-width 0.2.2",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "p2pem-desktop"
 version = "1.12.1"
 dependencies = [
  "anyhow",
  "directories",
- "encodeur_rsa_rust",
  "log",
  "messenger-core",
+ "p2pem-classic",
  "rfd",
  "serde",
  "serde_json",

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -7,7 +7,7 @@ This document is the technical guide for building, testing, changing, and releas
 - Rust: `1.86+`
 - Edition: `2021`
 - The repo is a Cargo **workspace** of four crates: `core/` (`messenger-core`),
-  `client/` (`encodeur_rsa_rust`), `server/` (`messenger-server`), and
+  `client/` (`p2pem-classic`), `server/` (`messenger-server`), and
   `desktop/src-tauri/` (`p2pem-desktop`). Bare `cargo` commands target the client.
 - Main entry points:
   - GUI/TUI launcher: `client/src/main.rs`
@@ -17,11 +17,12 @@ This document is the technical guide for building, testing, changing, and releas
   - Party server: `server/src/main.rs`
   - Tauri desktop bridge: `desktop/src-tauri/src/lib.rs`; React UI: `desktop/src/`
 
-> On crate naming: the client crate keeps its historical name `encodeur_rsa_rust`
-> for continuity, even though the protocol has long since moved to X25519-based
-> session establishment (RSA remains for identity signatures only). The product
-> name is **Encrypted P2P Messenger**; the Tauri desktop app uses the short
-> identifier **P2PEM**. See [docs/README.md](docs/README.md#naming) for the full map.
+> On crate naming: the client crate is `p2pem-classic` (renamed from the
+> historical `encodeur_rsa_rust`, an RSA-era name; the protocol has long since
+> moved to X25519-based session establishment, with RSA kept for identity
+> signatures only). The product name is **Encrypted P2P Messenger**; the Tauri
+> desktop app uses the short identifier **P2PEM**, and the egui/TUI app ships as
+> **P2PEM-Classic**. See [docs/README.md](docs/README.md#naming) for the full map.
 
 ## Build and Run
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,10 @@ The Tauri 2 desktop app (`p2pem-desktop`) adds a system-webview + IPC surface:
 - No STUN/TURN or peer-to-peer hole punching; WAN support currently relies on a self-hosted relay
 - LAN discovery exposes metadata tradeoffs when enabled
 - The runtime keeps a signature-scheme field on the wire, but currently only supports RSA-PSS identity proofs
-- Invite timestamps are informational and not enforced for expiry
+- Signed invites expire 30 days after issuance (the signature covers the
+  timestamp); legacy v1 unsigned invites carry no timestamp and are not
+  subject to expiry
+- Invite revocation (before expiry) is not supported
 - `rsa` still carries an unresolved upstream timing-sidechannel advisory (`RUSTSEC-2023-0071`)
 - `bincode` remains a tracked dependency migration concern
 
@@ -68,7 +71,7 @@ It does not currently claim:
 - anonymity against traffic analysis
 - managed relay infrastructure or anonymous global connectivity
 - Ed25519 identity-key support in the shipped runtime
-- invite revocation or expiry enforcement
+- invite revocation before the 30-day expiry
 - full protection against a compromised local machine
 
 ## Responsible Disclosure

--- a/build-and-package.ps1
+++ b/build-and-package.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
   build-and-package.ps1
   Build and package script for Encrypted P2P Messenger
   Usage example:

--- a/build-and-package.ps1
+++ b/build-and-package.ps1
@@ -58,7 +58,7 @@ try {
     Write-Host "Target:        $Target"
 
     # Nom du binaire produit par cargo (adapté à ton projet)
-    $BinaryName = "encodeur_rsa_rust.exe"
+    $BinaryName = "p2pem-classic.exe"
     $BinaryBase = [System.IO.Path]::GetFileNameWithoutExtension($BinaryName)
 
     # 1) Build release

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "encodeur_rsa_rust"
+name = "p2pem-classic"
 description = "Encrypted P2P Messenger - a secure peer-to-peer messaging application with end-to-end encryption and forward secrecy"
 version.workspace = true
 edition.workspace = true
@@ -8,11 +8,11 @@ license.workspace = true
 authors.workspace = true
 
 [lib]
-name = "encodeur_rsa_rust"
+name = "p2pem_classic"
 path = "src/lib.rs"
 
 [[bin]]
-name = "encodeur_rsa_rust"
+name = "p2pem-classic"
 path = "src/main.rs"
 
 [dependencies]

--- a/client/src/app/chat_manager/invites.rs
+++ b/client/src/app/chat_manager/invites.rs
@@ -125,6 +125,28 @@ impl ChatManager {
                 "Successfully verified v2 signed invite"
             );
 
+            // Enforce expiry: the timestamp is covered by the signature, so a
+            // stale or future-dated value cannot be forged without breaking
+            // verification above.
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let ts = signed_invite.payload.timestamp;
+            if ts > now + crate::INVITE_TIMESTAMP_SKEW_SECS {
+                tracing::warn!(timestamp = ts, now, "Rejecting invite dated in the future");
+                anyhow::bail!(
+                    "Invite timestamp is in the future - check the sender's clock and ask for a fresh invite"
+                );
+            }
+            if now.saturating_sub(ts) > crate::INVITE_MAX_AGE_SECS {
+                tracing::warn!(timestamp = ts, now, "Rejecting expired invite");
+                anyhow::bail!(
+                    "Invite has expired (older than {} days) - ask the sender for a fresh one",
+                    crate::INVITE_MAX_AGE_SECS / 86_400
+                );
+            }
+
             let payload = &signed_invite.payload;
 
             // Sanitize address: ignore placeholder or clearly invalid addresses like "YOUR_IP:PORT"

--- a/client/src/app/chat_manager/tests.rs
+++ b/client/src/app/chat_manager/tests.rs
@@ -384,6 +384,117 @@ fn parse_v2_signed_invite_rejects_tampered_signature() {
     );
 }
 
+/// Re-sign a fresh invite with a rewritten timestamp, keeping the signature
+/// valid, so parse-time expiry is exercised independently of signature checks.
+#[cfg(test)]
+fn resign_invite_with_timestamp(identity: &crate::identity::Identity, timestamp: u64) -> String {
+    use base64::Engine;
+
+    let link = identity.generate_signed_invite_link(None).unwrap();
+    let encoded = link.strip_prefix("chat-p2p://invite/v2/").unwrap();
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded)
+        .unwrap();
+
+    // Mirror the parser's payload struct so the signature covers bytes with
+    // the same field order it will re-serialize for verification.
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Payload {
+        version: u32,
+        timestamp: u64,
+        nonce: String,
+        name: String,
+        address: Option<String>,
+        relay_server: Option<String>,
+        relay_token: Option<String>,
+        fingerprint: String,
+        public_key: String,
+    }
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct SignedInvite {
+        payload: Payload,
+        signature: Vec<u8>,
+    }
+
+    let mut invite: SignedInvite = serde_json::from_slice(&decoded).unwrap();
+    invite.payload.timestamp = timestamp;
+
+    let payload_json = serde_json::to_string(&invite.payload).unwrap();
+    invite.signature = crate::core::crypto::rsa_sign_pss(
+        &identity.private_key().unwrap(),
+        payload_json.as_bytes(),
+    )
+    .unwrap();
+
+    let re_encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_string(&invite).unwrap());
+    format!("chat-p2p://invite/v2/{}", re_encoded)
+}
+
+#[test]
+fn parse_signed_invite_rejects_expired_timestamp() {
+    use crate::identity::Identity;
+
+    let mgr = ChatManager::default();
+    let identity = Identity::new_with_plaintext("Expiry Test".to_string()).unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expired = now - crate::INVITE_MAX_AGE_SECS - 60;
+    let link = resign_invite_with_timestamp(&identity, expired);
+
+    let err = mgr
+        .parse_invite_link(&link)
+        .expect_err("expired invite must be rejected");
+    assert!(
+        err.to_string().contains("expired"),
+        "error should mention expiry, got: {err}"
+    );
+}
+
+#[test]
+fn parse_signed_invite_rejects_future_timestamp() {
+    use crate::identity::Identity;
+
+    let mgr = ChatManager::default();
+    let identity = Identity::new_with_plaintext("Skew Test".to_string()).unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let future = now + crate::INVITE_TIMESTAMP_SKEW_SECS + 60;
+    let link = resign_invite_with_timestamp(&identity, future);
+
+    let err = mgr
+        .parse_invite_link(&link)
+        .expect_err("future-dated invite must be rejected");
+    assert!(
+        err.to_string().contains("future"),
+        "error should mention future timestamp, got: {err}"
+    );
+}
+
+#[test]
+fn parse_signed_invite_accepts_recent_timestamp_within_window() {
+    use crate::identity::Identity;
+
+    let mgr = ChatManager::default();
+    let identity = Identity::new_with_plaintext("Fresh Test".to_string()).unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    // A week old: well inside the 30-day window.
+    let link = resign_invite_with_timestamp(&identity, now - 7 * 86_400);
+
+    mgr.parse_invite_link(&link)
+        .expect("invite inside the expiry window must still parse");
+}
+
 #[test]
 fn parse_v1_invite_link_still_works_with_warning() {
     let mgr = ChatManager::default();

--- a/client/src/gui/chat_view.rs
+++ b/client/src/gui/chat_view.rs
@@ -150,6 +150,41 @@ pub fn render_chat(app: &mut App, ui: &mut egui::Ui, chat_id: Uuid) {
         .show_inside(ui, |ui| {
             ui.add_space(5.0);
 
+            // Live progress for this chat's in-flight file transfers (both
+            // directions), mirroring the desktop app's transfer bar.
+            let transfers: Vec<_> = if let Ok(manager) = app.chat_manager.try_lock() {
+                manager
+                    .active_transfers_snapshot()
+                    .into_iter()
+                    .filter(|t| t.chat_id == chat_id)
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            for t in &transfers {
+                let frac = if t.size > 0 {
+                    (t.received as f32 / t.size as f32).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
+                ui.horizontal(|ui| {
+                    ui.label(format!("📎 {}", t.filename));
+                    ui.add(
+                        egui::ProgressBar::new(frac)
+                            .desired_width(220.0)
+                            .text(format!(
+                                "{} / {}",
+                                crate::util::format_size(t.received),
+                                crate::util::format_size(t.size)
+                            )),
+                    );
+                });
+                // Keep repainting while a transfer is live so the bar moves
+                // without waiting for other UI activity.
+                ui.ctx()
+                    .request_repaint_after(std::time::Duration::from_millis(250));
+            }
+
             // File preview if selected
             if let Some(file_path) = app.file_to_send.clone() {
                 let filename = file_path

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -5,7 +5,7 @@
 use clap::Parser;
 
 use egui_tracing::tracing::EventCollector;
-use encodeur_rsa_rust::*;
+use p2pem_classic::*;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info,encodeur_rsa_rust=debug".into()),
+                .unwrap_or_else(|_| "info,p2pem_classic=debug".into()),
         )
         .with(event_collector.clone())
         .init();

--- a/client/src/tui/ui.rs
+++ b/client/src/tui/ui.rs
@@ -240,6 +240,12 @@ fn render_messages(f: &mut Frame, app: &mut TuiApp, area: Rect) {
     if chat.peer_typing {
         title.push_str("· typing… ");
     }
+    for t in app.chat_manager.active_transfers_snapshot() {
+        if t.chat_id == chat_id && t.size > 0 {
+            let pct = (t.received.saturating_mul(100) / t.size).min(100);
+            title.push_str(&format!("· 📎 {} {}% ", t.filename, pct));
+        }
+    }
     let border = if app.focus == TuiFocus::MessageView {
         BRAND_ACCENT
     } else {

--- a/client/tests/bug_diagnosis.rs
+++ b/client/tests/bug_diagnosis.rs
@@ -3,9 +3,9 @@
 #[cfg(test)]
 mod diagnostics {
     use base64::Engine;
-    use encodeur_rsa_rust::app::chat_manager::ChatManager;
-    use encodeur_rsa_rust::types::Config;
-    use encodeur_rsa_rust::util::sanitize_filename;
+    use p2pem_classic::app::chat_manager::ChatManager;
+    use p2pem_classic::types::Config;
+    use p2pem_classic::util::sanitize_filename;
 
     use uuid::Uuid;
 
@@ -31,7 +31,7 @@ mod diagnostics {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         manager.add_session_for_test(
             chat_id,
-            encodeur_rsa_rust::app::chat_manager::SessionHandle { from_app_tx: tx },
+            p2pem_classic::app::chat_manager::SessionHandle { from_app_tx: tx },
         );
 
         let dir = tempfile::tempdir().unwrap();
@@ -48,7 +48,7 @@ mod diagnostics {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         manager.add_session_for_test(
             chat_id,
-            encodeur_rsa_rust::app::chat_manager::SessionHandle { from_app_tx: tx },
+            p2pem_classic::app::chat_manager::SessionHandle { from_app_tx: tx },
         );
 
         let missing_path = std::env::temp_dir().join(format!("missing-{}.txt", Uuid::new_v4()));

--- a/client/tests/contact_fuzz_tests.rs
+++ b/client/tests/contact_fuzz_tests.rs
@@ -1,5 +1,5 @@
-use encodeur_rsa_rust::app::chat_manager::ChatManager;
-use encodeur_rsa_rust::types::Config;
+use p2pem_classic::app::chat_manager::ChatManager;
+use p2pem_classic::types::Config;
 use proptest::prelude::*;
 
 proptest! {

--- a/client/tests/contact_simulation_tests.rs
+++ b/client/tests/contact_simulation_tests.rs
@@ -1,5 +1,5 @@
-use encodeur_rsa_rust::app::chat_manager::ChatManager;
-use encodeur_rsa_rust::types::{Config, TrustState};
+use p2pem_classic::app::chat_manager::ChatManager;
+use p2pem_classic::types::{Config, TrustState};
 
 #[tokio::test]
 async fn simulation_contacts_lifecycle() {

--- a/client/tests/feature_coverage_tests.rs
+++ b/client/tests/feature_coverage_tests.rs
@@ -3,8 +3,8 @@
 //! lifecycle, incoming file-transfer state, typing indicators without a session,
 //! contact import/association, and invite QR generation.
 
-use encodeur_rsa_rust::app::chat_manager::ChatManager;
-use encodeur_rsa_rust::types::{Config, Contact, ToastLevel, TransferStatus, TrustState};
+use p2pem_classic::app::chat_manager::ChatManager;
+use p2pem_classic::types::{Config, Contact, ToastLevel, TransferStatus, TrustState};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
@@ -132,7 +132,7 @@ fn start_receiving_oversized_file_is_rejected() {
     let mut mgr = ChatManager::default();
     let chat = Uuid::new_v4();
     mgr.create_local_chat_for_test(chat, "Files".to_string());
-    let too_big = encodeur_rsa_rust::MAX_FILE_SIZE + 1;
+    let too_big = p2pem_classic::MAX_FILE_SIZE + 1;
     assert!(mgr.start_receiving_file(chat, "huge.bin", too_big).is_err());
 }
 

--- a/client/tests/integration_tests.rs
+++ b/client/tests/integration_tests.rs
@@ -1,5 +1,5 @@
-use encodeur_rsa_rust::app::chat_manager::ChatManager;
-use encodeur_rsa_rust::types::{Config, Theme};
+use p2pem_classic::app::chat_manager::ChatManager;
+use p2pem_classic::types::{Config, Theme};
 use rand::RngCore;
 use tempfile::NamedTempFile;
 use uuid::Uuid;

--- a/client/tests/key_rotation_tests.rs
+++ b/client/tests/key_rotation_tests.rs
@@ -6,10 +6,8 @@
 /// - Rotation happens at correct message/time intervals
 /// - Both peers rotate to the same key
 /// - Messages continue to flow correctly after rotation
-use encodeur_rsa_rust::core::{
-    generate_rekey_nonce, rekey_session_key, AesCipher, ProtocolMessage,
-};
-use encodeur_rsa_rust::AES_KEY_SIZE;
+use p2pem_classic::core::{generate_rekey_nonce, rekey_session_key, AesCipher, ProtocolMessage};
+use p2pem_classic::AES_KEY_SIZE;
 use rand::Rng;
 use std::time::Instant;
 

--- a/client/tests/messaging_tests.rs
+++ b/client/tests/messaging_tests.rs
@@ -1,6 +1,6 @@
-use encodeur_rsa_rust::app::chat_manager::{ChatManager, SessionHandle};
-use encodeur_rsa_rust::core::ProtocolMessage;
-use encodeur_rsa_rust::types::Config;
+use p2pem_classic::app::chat_manager::{ChatManager, SessionHandle};
+use p2pem_classic::core::ProtocolMessage;
+use p2pem_classic::types::Config;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 

--- a/client/tests/persistence_tests.rs
+++ b/client/tests/persistence_tests.rs
@@ -1,9 +1,9 @@
 //! Encrypted-history persistence: encrypted round-trip, wrong-key rejection,
 //! plaintext/encrypted auto-detection, and graceful handling of corrupt files.
 
-use encodeur_rsa_rust::app::chat_manager::ChatManager;
-use encodeur_rsa_rust::app::persistence::HistoryFile;
-use encodeur_rsa_rust::types::{Chat, ChatKind, Config, Message, MessageContent, Transport};
+use p2pem_classic::app::chat_manager::ChatManager;
+use p2pem_classic::app::persistence::HistoryFile;
+use p2pem_classic::types::{Chat, ChatKind, Config, Message, MessageContent, Transport};
 use std::io::Write;
 use uuid::Uuid;
 

--- a/client/tests/security_tests.rs
+++ b/client/tests/security_tests.rs
@@ -1,6 +1,6 @@
-use encodeur_rsa_rust::core::ProtocolMessage;
-use encodeur_rsa_rust::util::sanitize_filename;
-use encodeur_rsa_rust::{FILE_CHUNK_SIZE, MAX_FILE_SIZE, MAX_TEXT_MESSAGE_BYTES, TEXT_CHUNK_BYTES};
+use p2pem_classic::core::ProtocolMessage;
+use p2pem_classic::util::sanitize_filename;
+use p2pem_classic::{FILE_CHUNK_SIZE, MAX_FILE_SIZE, MAX_TEXT_MESSAGE_BYTES, TEXT_CHUNK_BYTES};
 use tempfile::TempDir;
 
 #[test]

--- a/client/tests/tui_command_tests.rs
+++ b/client/tests/tui_command_tests.rs
@@ -1,5 +1,5 @@
 use egui_tracing::tracing::EventCollector;
-use encodeur_rsa_rust::tui::app::{TuiApp, TuiCommand, TuiFocus, TuiMode};
+use p2pem_classic::tui::app::{TuiApp, TuiCommand, TuiFocus, TuiMode};
 use ratatui_crossterm::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use uuid::Uuid;
 
@@ -41,7 +41,7 @@ fn parse_commands_cover_party_channel_aliases_and_ipv6() {
         TuiApp::parse_command(":connect ::1").unwrap(),
         TuiCommand::Connect {
             host: "::1".to_string(),
-            port: encodeur_rsa_rust::PORT_DEFAULT,
+            port: p2pem_classic::PORT_DEFAULT,
         }
     );
 }

--- a/client/tests/tui_integration_tests.rs
+++ b/client/tests/tui_integration_tests.rs
@@ -1,7 +1,7 @@
 use egui_tracing::tracing::EventCollector;
-use encodeur_rsa_rust::app::chat_manager::SessionHandle;
-use encodeur_rsa_rust::core::ProtocolMessage;
-use encodeur_rsa_rust::tui::app::TuiApp;
+use p2pem_classic::app::chat_manager::SessionHandle;
+use p2pem_classic::core::ProtocolMessage;
+use p2pem_classic::tui::app::TuiApp;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 

--- a/client/tests/tui_loop_integration.rs
+++ b/client/tests/tui_loop_integration.rs
@@ -1,7 +1,7 @@
 use egui_tracing::tracing::EventCollector;
-use encodeur_rsa_rust::app::chat_manager::SessionHandle;
-use encodeur_rsa_rust::core::ProtocolMessage;
-use encodeur_rsa_rust::tui::app::{TuiApp, TuiCommand, TuiFocus};
+use p2pem_classic::app::chat_manager::SessionHandle;
+use p2pem_classic::core::ProtocolMessage;
+use p2pem_classic::tui::app::{TuiApp, TuiCommand, TuiFocus};
 use ratatui_crossterm::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tokio::sync::mpsc;
 use uuid::Uuid;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,3 +40,7 @@ pub const RSA_KEY_BITS: usize = 2048;
 pub const HANDSHAKE_TIMEOUT_SECS: u64 = 15;
 /// Maximum file size for transfers: 10 GiB
 pub const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024 * 1024; // 10 GiB
+/// Signed invites older than this are rejected at import (30 days).
+pub const INVITE_MAX_AGE_SECS: u64 = 30 * 24 * 60 * 60;
+/// Tolerated clock skew for invite timestamps that appear to be in the future.
+pub const INVITE_TIMESTAMP_SKEW_SECS: u64 = 60 * 60;

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -16,7 +16,8 @@
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.4",
         "@vitejs/plugin-react": "^6.0.3",
-        "vite": "^8.1.3"
+        "vite": "^8.1.3",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@emnapi/core": {
@@ -52,6 +53,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -175,9 +183,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -195,9 +200,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -215,9 +217,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -235,9 +234,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -255,9 +251,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -275,9 +268,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -361,6 +351,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -463,9 +460,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -483,9 +477,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -503,9 +494,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -523,9 +511,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -543,9 +528,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -617,6 +599,31 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
@@ -643,6 +650,146 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -651,6 +798,33 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -829,9 +1003,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -853,9 +1024,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -877,9 +1045,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -901,9 +1066,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -968,6 +1130,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -986,6 +1158,27 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1097,6 +1290,13 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1105,6 +1305,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1122,6 +1353,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1208,6 +1449,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tauri-apps/api": "~2.11.0",
@@ -18,7 +19,8 @@
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.4",
     "@vitejs/plugin-react": "^6.0.3",
-    "vite": "^8.1.3"
+    "vite": "^8.1.3",
+    "vitest": "^4.1.10"
   },
   "overrides": {
     "esbuild": "^0.25.0",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { workspace = true }
 # bridge reuses it directly. NOTE (tech debt, see Phase 1 spec): this pulls in
 # egui/ratatui transitively. A later phase should extract ChatManager into a
 # UI-agnostic crate so the webview build doesn't compile the legacy GUIs.
-encodeur_rsa_rust = { path = "../../client" }
+p2pem-classic = { path = "../../client" }
 messenger-core = { workspace = true }
 
 tokio = { workspace = true }

--- a/desktop/src-tauri/src/commands/party.rs
+++ b/desktop/src-tauri/src/commands/party.rs
@@ -67,7 +67,7 @@ fn party_status_parts(status: &PartyStatus) -> (&'static str, Option<String>) {
 /// Serialize one connection's directory (channels + members), resolving "you".
 fn server_dto(
     id: Uuid,
-    conn: &encodeur_rsa_rust::app::party_manager::PartyServerConn,
+    conn: &p2pem_classic::app::party_manager::PartyServerConn,
 ) -> PartyServerDto {
     let (status, status_detail) = party_status_parts(&conn.status);
     let members = conn
@@ -115,7 +115,7 @@ fn server_dto(
 /// from the member directory and flagging the local user's own messages.
 fn message_dto(
     env: &messenger_core::party::Envelope,
-    conn: &encodeur_rsa_rust::app::party_manager::PartyServerConn,
+    conn: &p2pem_classic::app::party_manager::PartyServerConn,
 ) -> PartyMessageDto {
     use messenger_core::party::MessagePayload;
     let sender_name = conn

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -17,8 +17,8 @@ use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use encodeur_rsa_rust::app::party_manager::{PartyManager, PartyStatus};
-use encodeur_rsa_rust::app::ChatManager;
+use p2pem_classic::app::party_manager::{PartyManager, PartyStatus};
+use p2pem_classic::app::ChatManager;
 
 /// Shared application state managed by Tauri.
 struct Bridge {
@@ -118,9 +118,7 @@ pub fn run() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                tracing_subscriber::EnvFilter::new(
-                    "info,encodeur_rsa_rust=debug,messenger_core=debug",
-                )
+                tracing_subscriber::EnvFilter::new("info,p2pem_classic=debug,messenger_core=debug")
             }),
         )
         .try_init();

--- a/desktop/src/lib/colorgrid.test.js
+++ b/desktop/src/lib/colorgrid.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { colorGrid } from "./colorgrid.js";
+
+const FP = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
+
+describe("colorGrid", () => {
+  it("fails closed on missing or non-hex input", () => {
+    expect(colorGrid(null)).toEqual([]);
+    expect(colorGrid(undefined)).toEqual([]);
+    expect(colorGrid("")).toEqual([]);
+    expect(colorGrid("zzz---!!!")).toEqual([]);
+  });
+
+  it("produces n*n hsl cells", () => {
+    const grid = colorGrid(FP);
+    expect(grid).toHaveLength(64);
+    for (const cell of grid) {
+      expect(cell).toMatch(/^hsl\(\d+ \d+% \d+%\)$/);
+    }
+    expect(colorGrid(FP, 4)).toHaveLength(16);
+  });
+
+  it("is deterministic for the same fingerprint", () => {
+    expect(colorGrid(FP)).toEqual(colorGrid(FP));
+  });
+
+  it("differs between fingerprints", () => {
+    const other = FP.replace(/^a1/, "b2");
+    expect(colorGrid(FP)).not.toEqual(colorGrid(other));
+  });
+
+  it("ignores separators and case in the fingerprint", () => {
+    const spaced = FP.toUpperCase().match(/.{4}/g).join(" ");
+    // Uppercasing changes charCodes, so only separator-stripping is invariant:
+    // the same fp with colons must hash identically to the bare form.
+    const colons = FP.match(/.{2}/g).join(":");
+    expect(colorGrid(colons)).toEqual(colorGrid(FP));
+    expect(colorGrid(spaced)).toHaveLength(64);
+  });
+});

--- a/desktop/src/lib/partyUnread.test.js
+++ b/desktop/src/lib/partyUnread.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { computeUnread, markRead } from "./partyUnread.js";
+
+// The module keeps one process-wide store, so every test uses its own server
+// id to stay independent of the others.
+let nextId = 0;
+const sid = () => `srv-${nextId++}`;
+
+const server = (id, channelCount, dmCount = undefined) => ({
+  id,
+  channels: [{ id: "general", messages: channelCount }],
+  members:
+    dmCount === undefined
+      ? []
+      : [
+          { id: "me", is_me: true, dm_messages: 999 },
+          { id: "peer", is_me: false, dm_messages: dmCount },
+        ],
+});
+
+describe("computeUnread", () => {
+  it("seeds the baseline on first sighting so old history is not unread", () => {
+    const id = sid();
+    const { total, byKey } = computeUnread([server(id, 40)]);
+    expect(total).toBe(0);
+    expect(byKey).toEqual({});
+  });
+
+  it("counts growth beyond the baseline", () => {
+    const id = sid();
+    computeUnread([server(id, 10)]);
+    const { total, byKey } = computeUnread([server(id, 13)]);
+    expect(total).toBe(3);
+    expect(byKey[`${id}|general`]).toBe(3);
+  });
+
+  it("never reports negative unread when counts shrink", () => {
+    const id = sid();
+    computeUnread([server(id, 10)]);
+    const { total } = computeUnread([server(id, 4)]);
+    expect(total).toBe(0);
+  });
+
+  it("tracks DM threads but skips the local member", () => {
+    const id = sid();
+    computeUnread([server(id, 0, 5)]);
+    const { total, byKey } = computeUnread([server(id, 0, 7)]);
+    expect(total).toBe(2);
+    expect(byKey[`${id}|dm-peer`]).toBe(2);
+    expect(Object.keys(byKey)).not.toContain(`${id}|dm-me`);
+  });
+
+  it("markRead clears a thread's unread count", () => {
+    const id = sid();
+    computeUnread([server(id, 10)]);
+    computeUnread([server(id, 15)]);
+    markRead(id, "general", 15);
+    const { total } = computeUnread([server(id, 15)]);
+    expect(total).toBe(0);
+  });
+});

--- a/desktop/src/lib/themes.test.js
+++ b/desktop/src/lib/themes.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { THEMES, loadTheme, saveTheme } from "./themes.js";
+
+const store = new Map();
+vi.stubGlobal("localStorage", {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => store.set(k, String(v)),
+  removeItem: (k) => store.delete(k),
+});
+
+beforeEach(() => store.clear());
+
+describe("theme registry", () => {
+  it("exposes the five canonical themes", () => {
+    expect(THEMES.map((t) => t.id).sort()).toEqual(
+      ["dark", "forest", "light", "midnight", "rose"].sort(),
+    );
+  });
+
+  it("defaults to dark when nothing is saved", () => {
+    expect(loadTheme()).toBe("dark");
+  });
+
+  it("round-trips a saved theme", () => {
+    saveTheme("forest");
+    expect(loadTheme()).toBe("forest");
+  });
+
+  it("falls back to dark for an unknown saved value", () => {
+    saveTheme("not-a-theme");
+    expect(loadTheme()).toBe("dark");
+  });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ predate the current name and are kept for compatibility and continuity:
 | Identifier | Where it appears | Meaning |
 |---|---|---|
 | `P2PEM` | Tauri desktop app (`p2pem-desktop`, window title, data dir) | Short product identifier for the new desktop app |
-| `encodeur_rsa_rust` | Client crate/binary name | Historical crate name; the protocol moved to X25519 session establishment long ago (RSA remains for identity signatures only) |
+| `p2pem-classic` | Client crate/binary name | Renamed from the historical `encodeur_rsa_rust` (an RSA-era name; the protocol moved to X25519 session establishment long ago, RSA remains for identity signatures only) |
 | `messenger-core` / `messenger-server` | Core and server crate names | Descriptive crate names |
 | `chat-p2p://` | Invite-link URI scheme | Wire-compatible URI scheme; renaming it would break existing invites |
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -36,8 +36,8 @@ cargo build --release
 
 Binary location:
 
-- Windows: `target\release\encodeur_rsa_rust.exe`
-- Linux/macOS: `target/release/encodeur_rsa_rust`
+- Windows: `target\release\p2pem-classic.exe`
+- Linux/macOS: `target/release/p2pem-classic`
 
 ### Linux build prerequisites
 
@@ -143,6 +143,8 @@ Invite links are the easiest way to hand a contact your identity details.
 Current behavior:
 
 - the app emits signed invite links
+- signed invites expire 30 days after they were generated; an expired invite
+  is rejected at import with a clear error - ask the sender for a fresh one
 - legacy unsigned invites may still import for compatibility
 - invalid addresses embedded in invites are dropped during import rather than trusted blindly
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ server, and the desktop shell can share code (see `docs/platform_spec.md`):
 ```text
 core/             messenger-core   — crypto, wire protocol, identity, transport, shared types,
                                      and the Party application protocol (core::party)
-client/           encodeur_rsa_rust — the unified app (egui GUI + ratatui TUI) and its binary
+client/           p2pem-classic — the unified app (egui GUI + ratatui TUI) and its binary
 server/           messenger-server  — the Party server (TCP listener, state, dispatcher, hub)
 desktop/src-tauri p2pem-desktop     — the Tauri 2 desktop shell that bridges the same
                                      ChatManager/PartyManager to a React/Vite web UI (desktop/src/)
@@ -19,7 +19,7 @@ desktop/src-tauri p2pem-desktop     — the Tauri 2 desktop shell that bridges t
 `client` depends on `core` and re-exports it (`pub use messenger_core::*;`), so the
 client modules and integration tests reach core types via the usual paths. The
 `p2pem-desktop` crate depends on `client` (for the managers) and wraps them in
-`#[tauri::command]`s. The client binary keeps the name `encodeur_rsa_rust`
+`#[tauri::command]`s. The client crate/binary is named `p2pem-classic`
 (packaging is unchanged; the release pipeline still ships that egui binary — the
 Tauri app is run from source during development). Bare `cargo build`/`test`/`run`
 target the client via `default-members`; CI builds the whole workspace with

--- a/docs/platform_spec.md
+++ b/docs/platform_spec.md
@@ -96,11 +96,11 @@ landed as React rather than the originally-planned SolidJS (see §10).
 
 ### Crate layout — Cargo workspace (done, four crates)
 
-Four crates: `core` (`messenger-core`), `client` (`encodeur_rsa_rust`, the
+Four crates: `core` (`messenger-core`), `client` (`p2pem-classic`, the
 unified app + binary), `server` (`messenger-server`), and `p2pem-desktop`
 (`desktop/src-tauri`, the Tauri shell). The client re-exports core via
 `pub use messenger_core::*`; the desktop crate depends on `client` for the
-managers. The client binary kept the `encodeur_rsa_rust` name so packaging paths
+managers. The client crate is `p2pem-classic` (renamed from `encodeur_rsa_rust`) and packaging paths
 are unchanged. Bare `cargo` commands still target the client.
 
 ---
@@ -147,7 +147,7 @@ desktop/src-tauri the Tauri 2 shell (p2pem-desktop): #[tauri::command] bridge + 
 Relay stays a thin mode (`--relay-server`) alongside `core`.
 
 **Binaries** ship from one repo/release: a default `client` binary (named
-`encodeur_rsa_rust` for packaging continuity) and the `messenger-server` binary.
+`p2pem-classic`) and the `messenger-server` binary.
 The `p2pem-desktop` binary builds via `cargo tauri build`/`dev` but is not yet in
 the tagged release pipeline (which still ships the egui `client` binary).
 
@@ -464,8 +464,8 @@ going unnoticed again.
 
 ### Packaging rebuild
 
-The current pipeline still assumes one eframe binary named `encodeur_rsa_rust`:
-`release.yml` builds `-p encodeur_rsa_rust` then hand-rolls Inno Setup
+The current pipeline still assumes one eframe binary named `p2pem-classic`:
+`release.yml` builds `-p p2pem-classic` then hand-rolls Inno Setup
 (`setup.iss`), a macOS `.app`+`.dmg`, and a Linux tarball; `build-and-package.ps1`
 and `setup.iss` hardcode that name. **Done:** `desktop/src-tauri/tauri.conf.json`
 already exists (productName `P2PEM`, identifier `com.chat-p2p.p2pem`, window

--- a/docs/platform_spec.md
+++ b/docs/platform_spec.md
@@ -570,7 +570,40 @@ update the canonical doc — `architecture.md`/`protocol.md` — in the same cha
 - Keep security docs accurate as implementation changes; keep dependency risk
   under review.
 - Harden mDNS registration/removal behavior and discovery privacy.
-- Stronger invite lifecycle controls: **invite expiration and revocation**.
+- Stronger invite lifecycle controls: signed-invite **expiration is enforced**
+  (30 days, timestamp covered by the signature); **revocation** before expiry
+  remains open.
+- **Ed25519 identity proofs** (planned, own dedicated change — see below).
+
+### Ed25519 migration plan (proposal, not started)
+
+The wire already carries a `SignatureScheme` field in `IdentityProof`, but only
+RSA-PSS is implemented, and the `rsa` crate carries the unresolved
+RUSTSEC-2023-0071 timing advisory. Moving identity proofs to Ed25519
+(`ed25519-dalek` is already a dependency) removes that exposure and shrinks
+handshakes, but it is **not** a drop-in swap because the peer **fingerprint is
+derived from the identity public key** — naively replacing the key would change
+every user's fingerprint and break TOFU continuity for all existing contacts.
+Planned shape:
+
+1. **Dual-key identities**: new identities get both an RSA-2048 and an Ed25519
+   keypair; existing identities grow an Ed25519 keypair on first unlock after
+   upgrade. The fingerprint stays RSA-derived for now (continuity).
+2. **Cross-signing**: the RSA key signs the Ed25519 public key once; the proof
+   travels with the identity so peers can bind the new key to the fingerprint
+   they already trust.
+3. **Scheme negotiation**: `IdentityProof` advertises both schemes; peers that
+   understand Ed25519 verify the Ed25519 proof (plus the cross-signature on
+   first sight), older peers keep verifying RSA-PSS. No protocol version bump
+   needed — the scheme field exists.
+4. **Fingerprint cutover** (last, separate release): once Ed25519-capable
+   versions are assumed, re-derive fingerprints from the Ed25519 key with an
+   explicit re-verification prompt (a UX event, not silent), then retire the
+   RSA path and the `rsa` dependency.
+
+Steps 1–3 are back-compatible; step 4 is a breaking trust-model event and needs
+its own comms/UX design. Each step lands with handshake tests on both the
+old/new peer matrix.
 
 **Connectivity**
 
@@ -582,7 +615,11 @@ update the canonical doc — `architecture.md`/`protocol.md` — in the same cha
 - Accessibility pass over interactions and color usage.
 - Settings IA cleanup / tabbed organization (folds into the §10 settings page).
 - Better contact management UX and trust-state workflows.
-- File-transfer progress and cancellation improvements.
+- File-transfer **progress** now shows in all three UIs (desktop transfer bar,
+  egui progress bar above the input, TUI title indicator); **cancellation**
+  remains open — it needs a wire-level abort message (`ProtocolMessage`
+  addition with symmetric encode/decode and replay-protected sequencing), so
+  it is its own protocol change rather than a UI patch.
 
 **Tracked long-horizon gaps** (intentionally not described as "done" anywhere):
 onion routing / anonymity layer, post-quantum migration, hardware-backed identity.

--- a/setup.iss
+++ b/setup.iss
@@ -4,7 +4,7 @@
 #define MyAppName "Encrypted P2P Messenger"
 #define MyAppPublisher "fibo3090"
 #define MyAppURL "https://github.com/fibo3090/secure-p2p-chat"
-#define MyAppExe "encodeur_rsa_rust.exe"
+#define MyAppExe "p2pem-classic.exe"
 
 ; Define icon only if it exists in dist
 #if FileExists("dist\app-icon.ico")
@@ -77,7 +77,7 @@ var
   ErrorCode: Integer;
 begin
   // Check if the application is running
-  // 'encodeur_rsa_rust.exe' should match the binary name
+  // 'p2pem-classic.exe' should match the binary name
   // Note: ShellExec requires specific parameters to kill. 
   // A simpler way in Inno is usually to check for the mutex or window, 
   // but since we don't have a specific mutex defined in Rust app yet, 


### PR DESCRIPTION
## Summary

Three commits, one theme: clearing the debt and gaps identified after the rebrand.

- **Crate rename `encodeur_rsa_rust` → `p2pem-classic`** (last RSA-era name in the repo): package, lib, and bin renamed to match the release artifacts; all imports (client tests, desktop bridge), packaging (release.yml, setup.iss, build-and-package.ps1), docs, and `RUST_LOG` examples updated; `Cargo.lock` regenerated for `--locked` CI builds. Data directories are untouched, so existing identities/history load unchanged.
- **Signed-invite expiry is now enforced**: invites older than 30 days (or future-dated beyond a 1-hour skew) are rejected at import with a clear error. The timestamp is covered by the invite's RSA-PSS signature, so it can't be re-dated without failing verification — proven by a test that re-signs a stale payload. Legacy v1 unsigned invites keep their import-with-warning behavior.
- **Transfer progress in all three UIs**: egui gains a live progress bar above the chat input and the TUI a percentage in the message-view title (the desktop app already had a transfer bar). Wire-level cancellation is explicitly deferred to a future protocol change (needs an abort frame) and documented in the backlog.
- **First automated tests for the desktop frontend**: vitest over the pure logic modules (`colorgrid`, `partyUnread`, `themes`) — 14 tests — plus a new CI `Frontend Build` job (`npm ci` + `npm test` + `npm run build`); previously a broken React frontend could pass CI because the committed `dist/` masked it.
- **Ed25519 migration plan** added to the platform-spec backlog as a four-step proposal (dual-key identities → RSA cross-signing → scheme negotiation → fingerprint cutover last). Deliberately not implemented here: fingerprints are RSA-derived, so a naive key swap would break TOFU continuity for every existing contact.
- Investigated the `libsqlite3-sys`/`cfg_select` build failure seen on newer rustc: `rusqlite 0.40.1`/`libsqlite3-sys 0.38.1` are already the latest releases and no upstream fix exists yet; CI's pinned stable toolchain is unaffected, so no change shipped.

## User Impact

- The running process/binary is now `p2pem-classic` (was `encodeur_rsa_rust`); build commands use `-p p2pem-classic`, and the Linux tarball's inner binary is renamed accordingly. `RUST_LOG` filters targeting `encodeur_rsa_rust=` must become `p2pem_classic=`.
- Old invite links (30+ days) stop importing with a clear "expired" error — users ask for a fresh invite.
- File sends/receives are visible in progress form in every UI.
- No protocol wire changes; no data-directory or identity changes.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p messenger-core -p p2pem-classic --all-targets -- -D warnings`
- [x] `cargo test -p messenger-core -p p2pem-classic` — 258 tests green under the new crate name, plus 3 new invite-expiry tests (expired rejected, future-dated rejected, fresh accepted)
- [x] `cargo check -p p2pem-desktop` (bridge compiles against the renamed dependency)
- [x] `npm test` (14 vitest tests) and `npm run build` in `desktop/`; `npm ci --dry-run` confirms the lockfile is coherent
- [x] Manual smoke test not applicable beyond the above — the release pipeline rename is validated at the next `v*` tag

## Docs And Release Notes

- [x] Docs updated: `SECURITY.md` (expiry now enforced), `docs/USER_GUIDE.md`, `docs/README.md` naming map, `docs/architecture.md`, `docs/platform_spec.md` (backlog + Ed25519 plan), `DEVELOPER_GUIDE.md`, `CLAUDE.md`
- [x] `CHANGELOG.md` updated (Added + Changed entries)
- [x] `SECURITY.md` reflects the new invite-expiry guarantee; no wire/protocol behavior changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01EgKKFA4jtYxrBouS2gtfui)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live file-transfer progress indicators across desktop, classic, and terminal interfaces.
  * Signed invite links now reject invites expired after 30 days and reject future-dated invites.
* **Bug Fixes**
  * Strengthened signed-invite import validation with clearer expiry/future-date handling.
* **Changed**
  * Release artifacts and build/logging now target the **p2pem-classic** client binary name.
* **Documentation**
  * Updated build, packaging, naming, and security/invite-link guidance for the new binary and 30-day expiry behavior.
* **Tests**
  * Added/expanded frontend test coverage and enabled automated frontend tests/builds in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->