### PR TITLE
fix(security): cap large-text chunk count to stop remote-OOM DoS

### DIFF
--- a/client/src/app/chat_manager/tests.rs
+++ b/client/src/app/chat_manager/tests.rs
@@ -1081,3 +1081,48 @@ fn delete_all_data_removes_files_and_clears_state() {
     assert!(mgr.contact_to_chat.is_empty());
     assert!(mgr.fingerprint_verification_request.is_none());
 }
+
+#[test]
+fn register_incoming_text_chunk_rejects_oversized_total_chunks() {
+    // Defense in depth beyond the wire decoder: a bogus total_chunks must not
+    // drive a giant reassembly-buffer allocation.
+    let mut mgr = ChatManager::default();
+    let chat_id = Uuid::new_v4();
+    let message_id = Uuid::new_v4();
+
+    let err = mgr
+        .register_incoming_text_chunk(chat_id, message_id, 0, u32::MAX, "x".to_string(), 0)
+        .expect_err("oversized total_chunks must be rejected");
+    assert!(err.to_string().contains("Invalid chunk count"));
+    // No buffer should have been created.
+    assert!(mgr.incoming_text_messages.is_empty());
+}
+
+#[test]
+fn register_incoming_text_chunk_caps_concurrent_partial_messages() {
+    let mut mgr = ChatManager::default();
+    let chat_id = Uuid::new_v4();
+
+    // Open the maximum number of distinct partial messages (each 2 chunks, so
+    // none completes and they all stay in flight).
+    for _ in 0..crate::MAX_CONCURRENT_PARTIAL_TEXT_PER_CHAT {
+        let message_id = Uuid::new_v4();
+        mgr.register_incoming_text_chunk(chat_id, message_id, 0, 2, "a".to_string(), 0)
+            .expect("within the concurrent cap");
+    }
+
+    // One more distinct message must be rejected.
+    let err = mgr
+        .register_incoming_text_chunk(chat_id, Uuid::new_v4(), 0, 2, "a".to_string(), 0)
+        .expect_err("beyond the concurrent cap must be rejected");
+    assert!(err.to_string().contains("Too many concurrent"));
+
+    // But a further chunk for an already-tracked message is still accepted.
+    let existing = *mgr
+        .incoming_text_messages
+        .keys()
+        .find(|(c, _)| *c == chat_id)
+        .expect("a partial message exists");
+    mgr.register_incoming_text_chunk(existing.0, existing.1, 1, 2, "b".to_string(), 0)
+        .expect("completing an existing message stays allowed");
+}

--- a/client/src/app/chat_manager/text.rs
+++ b/client/src/app/chat_manager/text.rs
@@ -32,6 +32,16 @@ impl ChatManager {
         let message_id = Uuid::new_v4();
         let total_chunks = u32::try_from(chunks.len())
             .map_err(|_| anyhow!("Message is too large to chunk safely"))?;
+        // Symmetric with the receiver's decode cap: refuse to build a message
+        // the peer would reject anyway, so the user gets a clear error instead
+        // of a silently dropped message.
+        if total_chunks > crate::MAX_TEXT_CHUNKS {
+            bail!(
+                "Message is too large to send (would need {} chunks, max {})",
+                total_chunks,
+                crate::MAX_TEXT_CHUNKS
+            );
+        }
         let mut messages = Vec::with_capacity(chunks.len());
 
         for (chunk_index, text_part) in chunks.into_iter().enumerate() {
@@ -107,9 +117,28 @@ impl ChatManager {
         text_part: String,
         timestamp_millis: u64,
     ) -> Result<Option<(String, chrono::DateTime<chrono::Utc>)>> {
+        // Defense in depth: the wire decoder already caps `total_chunks`, but
+        // guard here too so this buffer can never pre-allocate an unbounded
+        // number of slots regardless of how it is reached.
+        if total_chunks == 0 || total_chunks > crate::MAX_TEXT_CHUNKS {
+            bail!("Invalid chunk count for large text message");
+        }
+        let key = (chat_id, message_id);
+        // Bound the number of concurrent partial messages per chat so a peer
+        // cannot open many reassembly buffers and sit on memory until timeout.
+        if !self.incoming_text_messages.contains_key(&key) {
+            let in_flight = self
+                .incoming_text_messages
+                .keys()
+                .filter(|(c, _)| *c == chat_id)
+                .count();
+            if in_flight >= crate::MAX_CONCURRENT_PARTIAL_TEXT_PER_CHAT {
+                bail!("Too many concurrent large messages in flight for this chat");
+            }
+        }
         let entry = self
             .incoming_text_messages
-            .entry((chat_id, message_id))
+            .entry(key)
             .or_insert_with(|| IncomingTextMessage {
                 timestamp_millis,
                 parts: vec![None; total_chunks as usize],

--- a/core/src/core/protocol.rs
+++ b/core/src/core/protocol.rs
@@ -483,7 +483,13 @@ impl ProtocolMessage {
                 cursor += 4;
                 let total_chunks = u32::from_be_bytes(b[cursor..cursor + 4].try_into().ok()?);
                 cursor += 4;
-                if total_chunks == 0 || chunk_index >= total_chunks {
+                // Reject a huge `total_chunks` here: the reassembler allocates one
+                // slot per chunk up front, so an unbounded value is a remote-OOM
+                // vector. A capped, non-zero, in-range index is required.
+                if total_chunks == 0
+                    || total_chunks > crate::MAX_TEXT_CHUNKS
+                    || chunk_index >= total_chunks
+                {
                     return None;
                 }
                 let len = u32::from_be_bytes(b[cursor..cursor + 4].try_into().ok()?) as usize;
@@ -768,6 +774,43 @@ mod tests {
             seq: 1,
         };
         assert!(ProtocolMessage::from_plain_bytes(&oob.to_plain_bytes()).is_none());
+    }
+
+    #[test]
+    fn textchunk_total_chunks_cap_enforced_on_decode() {
+        // A frame whose total_chunks exceeds the cap must be rejected before it
+        // can drive a giant reassembly-buffer allocation (remote-OOM guard).
+        let over = ProtocolMessage::TextChunk {
+            message_id: Uuid::nil(),
+            chunk_index: 0,
+            total_chunks: crate::MAX_TEXT_CHUNKS + 1,
+            text_part: "x".to_string(),
+            timestamp: 1,
+            seq: 1,
+        };
+        assert!(ProtocolMessage::from_plain_bytes(&over.to_plain_bytes()).is_none());
+
+        // The exact cap is still allowed.
+        let at_cap = ProtocolMessage::TextChunk {
+            message_id: Uuid::nil(),
+            chunk_index: 0,
+            total_chunks: crate::MAX_TEXT_CHUNKS,
+            text_part: "x".to_string(),
+            timestamp: 1,
+            seq: 1,
+        };
+        assert!(ProtocolMessage::from_plain_bytes(&at_cap.to_plain_bytes()).is_some());
+
+        // A pathological u32::MAX (the original OOM vector) is rejected.
+        let huge = ProtocolMessage::TextChunk {
+            message_id: Uuid::nil(),
+            chunk_index: 0,
+            total_chunks: u32::MAX,
+            text_part: "x".to_string(),
+            timestamp: 1,
+            seq: 1,
+        };
+        assert!(ProtocolMessage::from_plain_bytes(&huge.to_plain_bytes()).is_none());
     }
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,6 +32,16 @@ pub const MAX_PACKET_SIZE: usize = 8 * 1024 * 1024; // 8 MiB
 pub const FILE_CHUNK_SIZE: usize = 64 * 1024; // 64 KiB
 pub const MAX_TEXT_MESSAGE_BYTES: usize = 64 * 1024; // 64 KiB
 pub const TEXT_CHUNK_BYTES: usize = 48 * 1024; // 48 KiB to leave headroom for metadata
+/// Upper bound on how many chunks one large text message may be split into,
+/// enforced symmetrically on send and receive. Caps a chunked message at
+/// `MAX_TEXT_CHUNKS * TEXT_CHUNK_BYTES` (~24 MiB) and — critically — stops a
+/// peer from sending a single `TextChunk` whose `total_chunks` is huge, which
+/// would make the reassembly buffer pre-allocate gigabytes (remote OOM/DoS).
+pub const MAX_TEXT_CHUNKS: u32 = 512;
+/// Cap on distinct in-flight large-message reassembly buffers per chat, so a
+/// peer cannot exhaust memory by opening many partial messages that each sit
+/// around until the reassembly timeout.
+pub const MAX_CONCURRENT_PARTIAL_TEXT_PER_CHAT: usize = 16;
 pub const AES_KEY_SIZE: usize = 32; // 256 bits
 pub const AES_NONCE_SIZE: usize = 12; // 96 bits (GCM standard)
 pub const AES_GCM_TAG_SIZE: usize = 16; // 128 bits (GCM authentication tag)


### PR DESCRIPTION
## Summary

A security audit of the untrusted-input paths in the session message loop turned up a **remotely triggerable out-of-memory crash** in large-text reassembly, plus a related soft memory-DoS. This PR fixes both with regression tests.

### The bug (confirmed, remote DoS)

`ProtocolMessage::TextChunk.total_chunks` is a peer-controlled `u32`. The wire decoder (`from_binary_tagged`, tag 11) validated only `total_chunks != 0` and `chunk_index < total_chunks` — it never bounded the magnitude. `register_incoming_text_chunk` then does:

```rust
parts: vec[None; total_chunks as usize]
```

So a single `TextChunk` frame with `total_chunks = 0xFFFFFFFF` makes the receiver pre-allocate `~4.3e9 * size_of::<Option<String>>()` ≈ **100 GB** and abort. Any peer past the TOFU gate could crash the app with one message. (The threat model explicitly includes an authenticated-but-malicious/compromised peer — that's what input validation is for.)

### Fixes

- **Primary guard — decode-time cap.** New `MAX_TEXT_CHUNKS` (512 → ~24 MiB assembled, very generous for a text message) rejected in `protocol.rs` *before any allocation*.
- **Symmetric send-side cap.** `build_text_protocol_messages` now errors clearly if a message would need more than `MAX_TEXT_CHUNKS` chunks, instead of emitting frames the peer will silently drop.
- **Defense in depth in the reassembler.** `register_incoming_text_chunk` re-checks the cap, and bounds the number of concurrent partial messages per chat (`MAX_CONCURRENT_PARTIAL_TEXT_PER_CHAT = 16`) so a peer can't open many half-open reassembly buffers that sit on memory until the 120 s timeout.

### Not changed (reported, not fixed here)

The audit also noted a subtle **robustness** concern (not a security hole): if both peers cross the rekey threshold and send an application message within one RTT of each other, they can initiate `Rekey` simultaneously and desync their keys, tearing the session down (it re-establishes on reconnect). A correct fix needs a small rekey-protocol change (deterministic initiator or a race-tolerant receive path) and deserves its own PR with focused tests — patching it hastily risks a rekey-liveness regression. Flagging it rather than half-fixing it.

## Verification

- [x] `cargo test -p messenger-core -p p2pem-classic` — **272 tests green** (3 new: decode cap rejects `> MAX_TEXT_CHUNKS` and `u32::MAX` while accepting the exact cap; reassembler rejects a bogus `total_chunks` without allocating; concurrent-partial cap rejects the 17th distinct message but still accepts further chunks for tracked ones)
- [x] `cargo clippy -p messenger-core -p p2pem-classic --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p p2pem-desktop`
- No wire-format or handshake changes; the new bounds only *reject* previously-accepted pathological inputs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgKKFA4jtYxrBouS2gtfui)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards for oversized or invalid chunked text messages.
  * Limited each chat to 16 simultaneous incomplete text messages.
  * Prevented invalid messages from allocating reassembly buffers.

* **Tests**
  * Added coverage for chunk limits, invalid indexes, excessive message counts, and continued processing of tracked messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->