### PR TITLE
release: cut 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ predate tagged releases.
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [1.14.0] - 2026-07-24
+
 ### Added
 
 - **File messages are no longer dead ends (desktop).** A finished file card
@@ -831,7 +835,8 @@ predate tagged releases.
 - Basic chat functionality, end-to-end encryption (RSA + AES-GCM), file
   transfer, a simple GUI, and message history persistence.
 
-[Unreleased]: https://github.com/fibo3090-code/secure-p2p-chat/compare/v1.13.0...HEAD
+[Unreleased]: https://github.com/fibo3090-code/secure-p2p-chat/compare/v1.14.0...HEAD
+[1.14.0]: https://github.com/fibo3090-code/secure-p2p-chat/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/fibo3090-code/secure-p2p-chat/compare/v1.12.1...v1.13.0
 [1.12.1]: https://github.com/fibo3090-code/secure-p2p-chat/compare/v1.12.0...v1.12.1
 [1.12.0]: https://github.com/fibo3090-code/secure-p2p-chat/compare/v1.11.1...v1.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "messenger-core"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "messenger-server"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5219,7 +5219,7 @@ dependencies = [
 
 [[package]]
 name = "p2pem-classic"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "p2pem-desktop"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["core", "client", "server", "desktop/src-tauri"]
 default-members = ["client"]
 
 [workspace.package]
-version = "1.13.0"
+version = "1.14.0"
 edition = "2021"
 rust-version = "1.86"
 authors = ["fibo3090 <fibo3090@example.com>"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Encrypted P2P Messenger
 
-[![Version](https://img.shields.io/badge/version-1.13.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.14.0-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-orange)](LICENSE.md)
 [![Security](https://img.shields.io/badge/security-medium-yellow)](SECURITY.md)
 [![Rust](https://img.shields.io/badge/rust-1.86+-orange)](https://www.rust-lang.org/)


### PR DESCRIPTION
Version bump only — no behaviour change. Everything shipping here is already on `main`.

## Contents

**Desktop (#72, #97)**
- File cards open the file with its default app, plus "show in folder". Only `(chat id, message id)` cross the bridge — never filesystem paths.
- Inline image previews (PNG/JPEG/GIF/WebP/BMP up to 4 MiB); SVG excluded as script-bearing.
- http(s) links in messages open in the system browser, scheme whitelisted bridge-side so a peer cannot make a message launch `file:` or app-scheme links.
- Day separators, times on file cards, last-activity in the conversation list.

**Security (#98, closes #33)**
- Unlock no longer reveals how the identity file is protected: recorded Argon2 parameters are the only ones tried, so an unlock costs one derivation instead of one-to-three depending on the file's vintage.
- Argon2 cost parameters read from a file are bounded (1 GiB, t≤16, p≤16) before use.

**Dependencies** — aes-gcm 0.11, getrandom 0.4, thiserror 2, vite 8.1.5, lucide-react 1.25.

## Compatibility

No wire-protocol or on-disk format change. Identity files written by any previous version still open — the two pre-`argon_params` schemes remain supported for files that carry no recorded parameters.

## Verification

`cargo nextest run --workspace` → **347/347**. clippy `--workspace --all-targets` and `cargo fmt --check` clean.

## After merge

Pushing the `v1.14.0` tag triggers `release.yml`, which creates the GitHub release and builds the assets. I have not tagged anything — that step is yours to authorise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)